### PR TITLE
fix(DTSW-7778): derive rosbridge host from request Host header

### DIFF
--- a/js/ros-config.js
+++ b/js/ros-config.js
@@ -78,28 +78,20 @@ window.ROSConfig = (function() {
          * Derives robot name from browser URL (less reliable but works as backup)
          */
         _getFallbackConfig: function() {
-            // Try to extract hostname from browser location
+            // Use whatever hostname the browser used to reach the dashboard.
+            // This is the most reliable signal: if the browser could load the
+            // page from this host, rosbridge on the same host is the best guess.
             let hostname = window.location.hostname;
-            
-            // Common fallback: if accessed via localhost/127.0.0.1, assume testdrone
-            if (hostname === 'localhost' || hostname === '127.0.0.1') {
-                hostname = 'testdrone.local';
-            }
-            
-            // If no domain, append .local
-            if (!hostname.includes('.')) {
-                hostname = hostname + '.local';
-            }
-            
+
             let is_https = window.location.protocol === 'https:';
             let scheme = is_https ? 'wss' : 'ws';
-            
+
             return {
-                vehicle_name: hostname.split('.')[0],  // Extract before .local
+                vehicle_name: hostname.split('.')[0],
                 robot_hostname: hostname,
-                rosbridge_url: `${scheme}://${hostname}:9090/rosbridge_websocket`,
+                rosbridge_url: `${scheme}://${hostname}:9001/rosbridge_websocket`,
                 rosbridge_host: hostname,
-                rosbridge_port: 9090,
+                rosbridge_port: 9001,
                 rosbridge_scheme: scheme,
                 timestamp: Math.floor(Date.now() / 1000),
                 _is_fallback: true

--- a/modules/renderers/endpoints/ros-config.php
+++ b/modules/renderers/endpoints/ros-config.php
@@ -18,8 +18,18 @@ header('Access-Control-Allow-Origin: *');
 
 // Get environment variables set by the dashboard container
 $vehicle_name = getenv('VEHICLE_NAME') ?: getenv('HOSTNAME') ?: 'unknown';
-$rosbridge_host = getenv('ROSBRIDGE_HOST') ?: $vehicle_name . '.local';
-$rosbridge_port = getenv('ROSBRIDGE_PORT') ?: 9090;
+
+// Derive the rosbridge host with this precedence:
+//   1. ROSBRIDGE_HOST env var (explicit operator override)
+//   2. The Host: header of the incoming request (strip any :port)
+//      — this is what the browser used to reach us, so it's reachable from the client
+//   3. VEHICLE_NAME.local (legacy last-resort fallback)
+$request_host = null;
+if (!empty($_SERVER['HTTP_HOST'])) {
+    $request_host = preg_replace('/:\d+$/', '', $_SERVER['HTTP_HOST']);
+}
+$rosbridge_host = getenv('ROSBRIDGE_HOST') ?: ($request_host ?: $vehicle_name . '.local');
+$rosbridge_port = getenv('ROSBRIDGE_PORT') ?: 9001;
 
 // Determine if we're behind HTTPS
 $is_https = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || 


### PR DESCRIPTION
## Summary
- `ros-config.php` now derives `rosbridge_host` from the incoming request's `Host:` header (port stripped), with `ROSBRIDGE_HOST` env var as an explicit operator override and `<vehicle>.local` as the legacy fallback.
- `js/ros-config.js` fallback drops the `localhost → testdrone.local` hardcode and trusts `window.location.hostname`.
- Default port bumped from 9090 → 9001 to match what rosbridge_websocket actually listens on.

Makes the dashboard proxy-agnostic: works via `<robot>.local`, `localhost:8080` (port-published virtual drone), and reverse proxies.

## Jira
DTSW-7778

## Test plan
- [ ] `curl http://<robot>.local:8080/api/ros-config` → `rosbridge_url: ws://<robot>.local:9001/...`
- [ ] `curl http://localhost:8080/api/ros-config` (virtual drone) → `rosbridge_url: ws://localhost:9001/...`
- [ ] Widgets connect and stream live data in both cases.