### PR TITLE
DTSW-7986-Update-Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ The `$id` is unique per widget instance; use it to namespace DOM ids and JS vari
 | File | Class | Purpose |
 |---|---|---|
 | `Duckiedrone_Arming.php` | `Mavros_Arming` | ARM/DISARM toggle + flight-mode toggle (OFFBOARD/ALTITUDE) + kill switch + takeoff button. Talks to mavros services. |
-| `Duckiedrone_Control.php` | `Duckiedrone_Control` | Virtual joystick publishing to `~/mavros/manual_control/send`. |
+| `Duckiedrone_Control.php` | `Duckiedrone_Control` | Virtual joystick publishing to `/mavros/manual_control/send`, reading `/mavros/state`, with optional legacy override params for older fly-commands mux setups. |
 | `Duckiedrone_Heartbeat.php` | `Duckiedrone_Heartbeat` | Single-topic heartbeat indicator. |
 | `Duckiedrone_Heartbeats_Monitor.php` | `Duckiedrone_Heartbeats_Monitor` | Multi-topic heartbeat grid for joystick / altitude / state_estimator / pid. |
-| `DuckietownMsgs_DroneMotorCommand.php` | `DuckietownMsgs_DroneMotorCommand` | Bar chart of the four motor PWM values. |
+| `DuckietownMsgs_DroneMotorCommand.php` | `DuckietownMsgs_DroneMotorCommand` | Bar chart of the four motor PWM values for legacy `flight_controller_node` deployments. |
+
+The current shell-managed Duckiedrone stacks use MAVROS and PX4 calibration endpoints by default. The shipped mission therefore targets `/mavros/*` and `/px4_calibration/*`; legacy `/flight_controller_node/*` and `/fly_commands_mux_node/*` hooks remain available only for manual compatibility with older deployments.
 
 ### Anatomy of a widget (writing a new one)
 
@@ -161,6 +163,8 @@ Edit `data/private/default_missions/duckietown_duckiedrone_missions/default.json
 The `renderer` field must match the PHP class name (not the filename).
 
 > **Known issue — `~/` path resolution.** The default mission currently ships with `~/mavros/...` paths for topics and services. On a virtual drone, rosbridge resolves `~` to `/<robot>/rosbridge_websocket`, not to `/`, so these services don't exist at that path and the corresponding widgets fail silently. Prefer absolute paths (`/mavros/cmd/arming`, `/mavros/state`, etc.) in new mission entries until the upstream `ROS::sanitize_hostname` behavior is fixed. See `docs/dashboard-test-report/README.md`.
+
+The default Duckiedrone mission in this repo already follows that rule for the live MAVROS and PX4 calibration endpoints.
 
 ---
 

--- a/data/private/default_missions/duckietown_duckiedrone_missions/default.json
+++ b/data/private/default_missions/duckietown_duckiedrone_missions/default.json
@@ -18,22 +18,6 @@
             },
             {
                 "shape": {
-                    "rows": 2,
-                    "cols": 5
-                },
-                "renderer": "DuckietownMsgs_DroneMotorCommand",
-                "title": "Motors PWM",
-                "subtitle": "/flight_controller_node/motors",
-                "args": {
-                    "ros_hostname": "",
-                    "topic": "~/flight_controller_node/motors",
-                    "fps": 5,
-                    "min_value": 1000,
-                    "max_value": 2000
-                }
-            },
-            {
-                "shape": {
                     "rows": 1,
                     "cols": 3
                 },
@@ -44,16 +28,12 @@
                     "ros_hostname": "",
                     "topic1": "~/joystick/heartbeat",
                     "label1": "JOYSTICK",
-                    "override1": "~/flight_controller_node/heartbeats/joystick",
                     "topic2": "~/altitude_node/heartbeat",
                     "label2": "ALTITUDE",
-					"override2": "~/flight_controller_node/heartbeats/altitude",
                     "topic3": "~/state_estimator_node/heartbeat",
                     "label3": "STATE",
-					"override3": "~/flight_controller_node/heartbeats/state_estimator",
                     "topic4": "~/pid_controller_node/heartbeat",
                     "label4": "PID",
-					"override4": "~/flight_controller_node/heartbeats/pid",
                     "threshold": 2,
                     "frequency": 2,
                     "background_color": "#fff"
@@ -69,12 +49,13 @@
 				"subtitle": "Control the drone using a virtual joystick",
 				"args": {
 					"ros_hostname": "",
-					"service_set_mode": "~/flight_controller_node\/set_mode",
+                    "service_set_mode": "",
+                    "arming_service": "/mavros\/cmd\/arming",
 					"service_override_commands": "",
-					"param_override_prefix": "~/fly_commands_mux_node\/",
-					"topic_mode_current": "~/flight_controller_node\/mode\/current",
-					"topic_control": "~/mavros/manual_control/send",
-					"topic_commands": "~/flight_controller_node\/commands\/executed",
+                    "param_override_prefix": "",
+                    "topic_mode_current": "/mavros\/state",
+                    "topic_control": "/mavros\/manual_control\/send",
+                    "topic_commands": "/mavros\/manual_control\/send",
 					"frequency": 30,
 					"max_roll_pitch": 300,
 					"min_value": 1000,

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -22,32 +22,44 @@ class Duckiedrone_Control extends BlockRenderer {
         "service_set_mode" => [
             "name" => "ROS Service (Set mode)",
             "type" => "text",
-            "mandatory" => True
+            "mandatory" => False,
+            "default" => ""
+        ],
+        "arming_service" => [
+            "name" => "ROS Service (ARM/DISARM)",
+            "type" => "text",
+            "mandatory" => False,
+            "default" => "/mavros/cmd/arming"
         ],
         "service_override_commands" => [
             "name" => "ROS Service (Set commands override)",
             "type" => "text",
-            "mandatory" => True
+            "mandatory" => False,
+            "default" => ""
         ],
         "param_override_prefix" => [
             "name" => "ROS Param Prefix (Command override)",
             "type" => "text",
-            "mandatory" => True
+            "mandatory" => False,
+            "default" => ""
         ],
         "topic_mode_current" => [
             "name" => "ROS Topic (Read mode)",
             "type" => "text",
-            "mandatory" => True
+            "mandatory" => True,
+            "default" => "/mavros/state"
         ],
         "topic_control" => [
             "name" => "ROS Topic (Joystick control)",
             "type" => "text",
-            "mandatory" => True
+            "mandatory" => True,
+            "default" => "/mavros/manual_control/send"
         ],
         "topic_commands" => [
             "name" => "ROS Topic (Read commands)",
             "type" => "text",
-            "mandatory" => True
+            "mandatory" => True,
+            "default" => "/mavros/manual_control/send"
         ],
         "frequency" => [
             "name" => "Frequency (Hz)",
@@ -82,6 +94,20 @@ class Duckiedrone_Control extends BlockRenderer {
     ];
     
     protected static function render($id, &$args) {
+        $ros_hostname = $args['ros_hostname'] ?? null;
+        $ros_hostname = ROS::sanitize_hostname($ros_hostname);
+        $connected_evt = ROS::get_event(ROS::$ROSBRIDGE_CONNECTED, $ros_hostname);
+        $override_param_prefix = trim($args['param_override_prefix'] ?? '');
+        $has_override_params = strlen($override_param_prefix) > 0;
+        $override_disabled_attr = $has_override_params ? '' : 'disabled';
+        $mode_topic = $args['topic_mode_current'] ?? self::$ARGUMENTS['topic_mode_current']['default'];
+        $control_topic = $args['topic_control'] ?? self::$ARGUMENTS['topic_control']['default'];
+        $commands_topic = $args['topic_commands'] ?? $control_topic;
+        if (strlen($commands_topic) <= 0) {
+            $commands_topic = $control_topic;
+        }
+        $arming_service = $args['arming_service'] ?? self::$ARGUMENTS['arming_service']['default'];
+        $legacy_set_mode_service = trim($args['service_set_mode'] ?? '');
         ?>
         <table class="resizable" style="height: 100%">
             <tr style="height: 20px; font-weight: bold">
@@ -134,6 +160,7 @@ class Duckiedrone_Control extends BlockRenderer {
                                data-offstyle="warning"
                                data-class="fast"
                                data-size="mini"
+                               <?php echo $override_disabled_attr ?>
                                name="drone_control_commands_override_<?php echo $bar["id"] ?>"
                                id="drone_control_commands_override_<?php echo $bar["id"] ?>">
                     </td>
@@ -153,12 +180,6 @@ class Duckiedrone_Control extends BlockRenderer {
             ?>
         </table>
         
-        <?php
-        $ros_hostname = $args['ros_hostname'] ?? null;
-        $ros_hostname = ROS::sanitize_hostname($ros_hostname);
-        $connected_evt = ROS::get_event(ROS::$ROSBRIDGE_CONNECTED, $ros_hostname);
-        ?>
-
         <!-- Include ROS -->
         <script src="<?php echo Core::getJSscriptURL('rosdb.js', 'ros') ?>"></script>
         <!-- Include Joy library -->
@@ -255,54 +276,71 @@ class Duckiedrone_Control extends BlockRenderer {
             }
       
             $(document).on("<?php echo $connected_evt ?>", function (evt) {
-                // TODO: this is the right way to do it
-                let set_override_srv = new ROSLIB.Service({
-                    ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name : '<?php echo $args['service_override_commands'] ?>',
-                    messageType : 'duckietown_msgs/SetDroneCommandsOverride'
-                });
-                
-                let roll_override = new ROSLIB.Param({
-                    ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name: '<?php echo $args['param_override_prefix'] ?>roll_override',
-                });
-                roll_override.get((v) => {
-                    let status = (v)? 'on' : 'off';
-                    $('#<?php echo $id ?> #drone_control_commands_override_roll').bootstrapToggle(status);
-                });
-                
-                let pitch_override = new ROSLIB.Param({
-                    ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name: '<?php echo $args['param_override_prefix'] ?>pitch_override',
-                });
-                pitch_override.get((v) => {
-                    let status = (v)? 'on' : 'off';
-                    $('#<?php echo $id ?> #drone_control_commands_override_pitch').bootstrapToggle(status);
-                });
-                
-                let yaw_override = new ROSLIB.Param({
-                    ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name: '<?php echo $args['param_override_prefix'] ?>yaw_override',
-                });
-                yaw_override.get((v) => {
-                    let status = (v)? 'on' : 'off';
-                    $('#<?php echo $id ?> #drone_control_commands_override_yaw').bootstrapToggle(status);
-                });
-                
-                let throttle_override = new ROSLIB.Param({
-                    ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name: '<?php echo $args['param_override_prefix'] ?>throttle_override',
-                });
-                throttle_override.get((v) => {
-                    let status = (v)? 'on' : 'off';
-                    $('#<?php echo $id ?> #drone_control_commands_override_throttle').bootstrapToggle(status);
-                });
-                
-                let set_mode_srv = new ROSLIB.Service({
-                    ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name : '<?php echo $args['service_set_mode'] ?>',
-                    messageType : 'duckietown_msgs/SetDroneMode'
-                });
+                const hasOverrideParams = <?php echo $has_override_params ? 'true' : 'false' ?>;
+                let roll_override = null;
+                let pitch_override = null;
+                let yaw_override = null;
+                let throttle_override = null;
+
+                if (hasOverrideParams) {
+                    roll_override = new ROSLIB.Param({
+                        ros: window.ros['<?php echo $ros_hostname ?>'],
+                        name: '<?php echo $override_param_prefix ?>roll_override',
+                    });
+                    roll_override.get((v) => {
+                        let status = (v)? 'on' : 'off';
+                        $('#<?php echo $id ?> #drone_control_commands_override_roll').bootstrapToggle(status);
+                    });
+
+                    pitch_override = new ROSLIB.Param({
+                        ros: window.ros['<?php echo $ros_hostname ?>'],
+                        name: '<?php echo $override_param_prefix ?>pitch_override',
+                    });
+                    pitch_override.get((v) => {
+                        let status = (v)? 'on' : 'off';
+                        $('#<?php echo $id ?> #drone_control_commands_override_pitch').bootstrapToggle(status);
+                    });
+
+                    yaw_override = new ROSLIB.Param({
+                        ros: window.ros['<?php echo $ros_hostname ?>'],
+                        name: '<?php echo $override_param_prefix ?>yaw_override',
+                    });
+                    yaw_override.get((v) => {
+                        let status = (v)? 'on' : 'off';
+                        $('#<?php echo $id ?> #drone_control_commands_override_yaw').bootstrapToggle(status);
+                    });
+
+                    throttle_override = new ROSLIB.Param({
+                        ros: window.ros['<?php echo $ros_hostname ?>'],
+                        name: '<?php echo $override_param_prefix ?>throttle_override',
+                    });
+                    throttle_override.get((v) => {
+                        let status = (v)? 'on' : 'off';
+                        $('#<?php echo $id ?> #drone_control_commands_override_throttle').bootstrapToggle(status);
+                    });
+                } else {
+                    let override_inputs = $('#<?php echo $id ?> input[id^="drone_control_commands_override_"]');
+                    override_inputs.bootstrapToggle('off');
+                    override_inputs.bootstrapToggle('disable');
+                }
+
+                let arming_srv = null;
+                if ('<?php echo $arming_service ?>'.length > 0) {
+                    arming_srv = new ROSLIB.Service({
+                        ros: window.ros['<?php echo $ros_hostname ?>'],
+                        name : '<?php echo $arming_service ?>',
+                        serviceType : 'mavros_msgs/CommandBool'
+                    });
+                }
+
+                let legacy_set_mode_srv = null;
+                if ('<?php echo $legacy_set_mode_service ?>'.length > 0) {
+                    legacy_set_mode_srv = new ROSLIB.Service({
+                        ros: window.ros['<?php echo $ros_hostname ?>'],
+                        name : '<?php echo $legacy_set_mode_service ?>',
+                        serviceType : 'duckietown_msgs/SetDroneMode'
+                    });
+                }
             
                 let ctx = document.getElementById("drone_control_commands_joy_keys").getContext('2d');
                 
@@ -322,30 +360,32 @@ class Duckiedrone_Control extends BlockRenderer {
                 
                 let armed = false;
             
-                $('#<?php echo $id ?> #drone_control_commands_override_roll').change(function() {
-                    let checked = $(this).prop('checked');
-                    roll_override.set(checked);
-                });
-            
-                $('#<?php echo $id ?> #drone_control_commands_override_pitch').change(function() {
-                    let checked = $(this).prop('checked');
-                    pitch_override.set(checked);
-                });
-            
-                $('#<?php echo $id ?> #drone_control_commands_override_yaw').change(function() {
-                    let checked = $(this).prop('checked');
-                    yaw_override.set(checked);
-                });
-            
-                $('#<?php echo $id ?> #drone_control_commands_override_throttle').change(function() {
-                    let checked = $(this).prop('checked');
-                    throttle_override.set(checked);
-                });
+                if (hasOverrideParams) {
+                    $('#<?php echo $id ?> #drone_control_commands_override_roll').change(function() {
+                        let checked = $(this).prop('checked');
+                        roll_override.set(checked);
+                    });
+
+                    $('#<?php echo $id ?> #drone_control_commands_override_pitch').change(function() {
+                        let checked = $(this).prop('checked');
+                        pitch_override.set(checked);
+                    });
+
+                    $('#<?php echo $id ?> #drone_control_commands_override_yaw').change(function() {
+                        let checked = $(this).prop('checked');
+                        yaw_override.set(checked);
+                    });
+
+                    $('#<?php echo $id ?> #drone_control_commands_override_throttle').change(function() {
+                        let checked = $(this).prop('checked');
+                        throttle_override.set(checked);
+                    });
+                }
                 
                 // subscribe to control signals
                 (new ROSLIB.Topic({
                     ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name: '<?php echo $args["topic_commands"] ?>',
+                    name: '<?php echo $commands_topic ?>',
                     messageType: 'mavros_msgs/ManualControl',
                     queue_size: 1,
                     throttle_rate: <?php echo 1000 / $args['frequency'] ?>
@@ -364,7 +404,7 @@ class Duckiedrone_Control extends BlockRenderer {
                 //subscribe to mode
                 (new ROSLIB.Topic({
                     ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name: '<?php echo $args["topic_mode_current"] ?>',
+                    name: '<?php echo $mode_topic ?>',
                     messageType: 'mavros_msgs/State',
                     queue_size: 1,
                     throttle_rate: <?php echo 1000 / $args['frequency'] ?>
@@ -375,7 +415,7 @@ class Duckiedrone_Control extends BlockRenderer {
                 // joystick commands publisher
                 const joystick_topic = new ROSLIB.Topic({
                     ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name: '<?php echo $args["topic_control"] ?>',
+                    name: '<?php echo $control_topic ?>',
                     messageType: 'mavros_msgs/ManualControl',
                     queue_size: 1
                 });
@@ -395,10 +435,17 @@ class Duckiedrone_Control extends BlockRenderer {
                 }
                 
                 function disarm_drone() {
-                    // disarm drone
-                    let request = new ROSLIB.ServiceRequest({mode: {mode: 0}});
-                    // send request
-                    set_mode_srv.callService(request, (_) => {});
+                    if (arming_srv !== null) {
+                        let request = new ROSLIB.ServiceRequest({value: false});
+                        arming_srv.callService(request, (_) => {});
+                        return;
+                    }
+                    if (legacy_set_mode_srv !== null) {
+                        let request = new ROSLIB.ServiceRequest({mode: {mode: 0}});
+                        legacy_set_mode_srv.callService(request, (_) => {});
+                        return;
+                    }
+                    console.warn('No disarm service configured for Duckiedrone_Control.');
                 }
                 
                 function map_to_real(k_front, k_back, k_left, k_right) {

--- a/modules/renderers/blocks/Duckiedrone_Heartbeats_Monitor.php
+++ b/modules/renderers/blocks/Duckiedrone_Heartbeats_Monitor.php
@@ -161,6 +161,7 @@ class Duckiedrone_Heartbeats_Monitor extends BlockRenderer {
                 for ($i = 1; $i <= 4; $i++) {
                     if (is_null($args["topic{$i}"]) || strlen($args["topic{$i}"]) <= 0)
                         continue
+                    $override_name = trim($args["override{$i}"] ?? '');
                     ?>
                     _heartbeats['<?php echo "heart{$i}" ?>'] = 0.0;
                     (new ROSLIB.Topic({
@@ -173,19 +174,20 @@ class Duckiedrone_Heartbeats_Monitor extends BlockRenderer {
                         _heartbeats['<?php echo "heart{$i}" ?>'] = seconds_since_epoch();
                         _heartbeat_turn_to_color("<?php echo "heart{$i}" ?>", "green");
                     });
-                    
+                    <?php if (strlen($override_name) > 0) { ?>
                     let <?php echo "heart{$i}" ?> = new ROSLIB.Param({
                         ros: window.ros['<?php echo $ros_hostname ?>'],
-                        name: '<?php echo $args["override{$i}"] ?>',
+                        name: '<?php echo $override_name ?>',
                     });
                     <?php echo "heart{$i}" ?>.get((v) => {
                         _heartbeats_override['<?php echo "heart{$i}" ?>'] = v;
                     });
-                    
+
                     $("#<?php echo $id ?> #heartbeats-monitor-<?php echo "heart{$i}" ?>").on("click", () => {
                         _heartbeats_override['<?php echo "heart{$i}" ?>'] = !(_heartbeats_override['<?php echo "heart{$i}" ?>'] ?? true);
                         <?php echo "heart{$i}" ?>.set(_heartbeats_override['<?php echo "heart{$i}" ?>']);
                     });
+                    <?php } ?>
                     <?php
                 }
                 ?>

--- a/modules/renderers/blocks/Duckiedrone_Heartbeats_Monitor.php
+++ b/modules/renderers/blocks/Duckiedrone_Heartbeats_Monitor.php
@@ -119,7 +119,7 @@ class Duckiedrone_Heartbeats_Monitor extends BlockRenderer {
                     <?php
                     for ($i = 1; $i <= 4; $i++) {
                         if (is_null($args["topic{$i}"]) || strlen($args["topic{$i}"]) <= 0)
-                            continue
+                            continue;
                         ?>
                         <td class="col-md-3 heartbeats-monitor-heart<?php echo $i ?>">
                             <span id="heartbeats-monitor-heart<?php echo $i ?>" class="glyphicon glyphicon-heart" aria-hidden="true"></span>
@@ -131,7 +131,7 @@ class Duckiedrone_Heartbeats_Monitor extends BlockRenderer {
                 <tr style="font-family: monospace; font-size: 8pt"><?php
                     for ($i = 1; $i <= 4; $i++) {
                         if (is_null($args["topic{$i}"]) || strlen($args["topic{$i}"]) <= 0)
-                            continue
+                            continue;
                         ?>
                         <td class="col-md-3 heartbeats-monitor-heart<?php echo $i ?>">
                             <?php echo $args["label{$i}"] ?>
@@ -160,7 +160,7 @@ class Duckiedrone_Heartbeats_Monitor extends BlockRenderer {
                 <?php
                 for ($i = 1; $i <= 4; $i++) {
                     if (is_null($args["topic{$i}"]) || strlen($args["topic{$i}"]) <= 0)
-                        continue
+                        continue;
                     $override_name = trim($args["override{$i}"] ?? '');
                     ?>
                     _heartbeats['<?php echo "heart{$i}" ?>'] = 0.0;


### PR DESCRIPTION
This pull request updates the default Duckiedrone dashboard and its widgets to use the modern MAVROS and PX4 endpoints, removing most legacy `flight_controller_node` and `fly_commands_mux_node` dependencies. The changes modernize the mission configuration, improve compatibility with current Duckiedrone stacks, and make the codebase more robust and maintainable. Legacy support is now optional and disabled by default, but can be enabled for older deployments.

**Mission and Widget Modernization**

- Updated the default Duckiedrone mission (`default.json`) to use `/mavros/*` and `/px4_calibration/*` endpoints for all control, state, and heartbeat topics, removing most legacy `flight_controller_node` and `fly_commands_mux_node` references. This includes removing the legacy motors PWM widget and updating all relevant topics and parameters. [[1]](diffhunk://#diff-c1a436bf34387089d52d13e4608c59cdcd878167d8a567dab10d4948a828b32aL19-L34) [[2]](diffhunk://#diff-c1a436bf34387089d52d13e4608c59cdcd878167d8a567dab10d4948a828b32aL47-L56) [[3]](diffhunk://#diff-c1a436bf34387089d52d13e4608c59cdcd878167d8a567dab10d4948a828b32aL72-R58)
- Updated documentation in `README.md` to clarify the new default endpoints, the rationale for preferring absolute paths, and the continued (optional) support for legacy endpoints for backward compatibility. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R167-R168)

**Widget Code Improvements**

- Refactored `Duckiedrone_Control.php` to:
  - Add explicit support for MAVROS arming/disarming and state topics, with new arguments and sensible defaults.
  - Make legacy override parameters and services optional, disabling related UI controls when not configured.
  - Ensure all topic/service names default to modern endpoints, but allow manual override for legacy compatibility.
  - Improve robustness by disabling override toggles if not configured and warning if no arming/disarm service is available. [[1]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51L25-R62) [[2]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51R97-R110) [[3]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51R163) [[4]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51L156-L161) [[5]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51L258-R343) [[6]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51R363) [[7]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51R383-R388) [[8]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51L367-R407) [[9]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51L378-R418) [[10]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51L398-R448)

**Minor Fixes and Cleanups**

- Fixed missing semicolons in `Duckiedrone_Heartbeats_Monitor.php` and improved handling of optional override parameters for heartbeat monitoring. [[1]](diffhunk://#diff-ff02575ad51dc28707408a8cdbd5b0f0e6f13bcf960d2ad32b58e6fade3597c1L122-R122) [[2]](diffhunk://#diff-ff02575ad51dc28707408a8cdbd5b0f0e6f13bcf960d2ad32b58e6fade3597c1L134-R134) [[3]](diffhunk://#diff-ff02575ad51dc28707408a8cdbd5b0f0e6f13bcf960d2ad32b58e6fade3597c1L163-R164) [[4]](diffhunk://#diff-ff02575ad51dc28707408a8cdbd5b0f0e6f13bcf960d2ad32b58e6fade3597c1L176-R180)