### PR TITLE
DTSW-8068-add-STABILIZED-mode-and-dependent-assets

### DIFF
--- a/modules/renderers/blocks/Duckiedrone_Arming.php
+++ b/modules/renderers/blocks/Duckiedrone_Arming.php
@@ -125,6 +125,8 @@ class Mavros_Arming extends BlockRenderer {
             <div class="col">
                 <div class="col-label">FLIGHT MODE</div>
                 <div class="btn-group-vertical btn-group-xs" role="group" id="drone_mode_selector">
+                    <button type="button" class="btn btn-default" data-mode="STABILIZED"
+                            title="PX4 STABILIZED — manual attitude control that self-levels; needs no GPS or altitude estimate. Use this for manual flight.">STABILIZED</button>
                     <button type="button" class="btn btn-default" data-mode="AUTO.LOITER"
                             title="PX4 AUTO.LOITER — position/altitude hold, safe armable default">LOITER</button>
                     <button type="button" class="btn btn-default" data-mode="ALTCTL"
@@ -169,12 +171,13 @@ class Mavros_Arming extends BlockRenderer {
         <script src="<?php echo Core::getJSscriptURL('rosdb.js', 'ros') ?>"></script>
 
         <script type="text/javascript">
+            let _MODE_STABILIZED = 'STABILIZED';
             let _MODE_LOITER = 'AUTO.LOITER';
             let _MODE_ALTITUDE = 'ALTCTL';
             let _MODE_OFFBOARD = 'OFFBOARD';
             let _MODE_AUTO_TAKEOFF = 'AUTO.TAKEOFF';
             let _MODE_AUTO_LAND = 'AUTO.LAND';
-            let _SELECTABLE_MODES = [_MODE_LOITER, _MODE_ALTITUDE, _MODE_OFFBOARD];
+            let _SELECTABLE_MODES = [_MODE_STABILIZED, _MODE_LOITER, _MODE_ALTITUDE, _MODE_OFFBOARD];
 
             // Track states
             let isArmed = false;

--- a/modules/renderers/blocks/Duckiedrone_Arming.php
+++ b/modules/renderers/blocks/Duckiedrone_Arming.php
@@ -562,8 +562,9 @@ class Mavros_Arming extends BlockRenderer {
                         if (message.mode !== currentMode) {
                             currentMode = message.mode;
                             // Only highlight the button if the reported mode is one of the
-                            // three selectable modes; otherwise clear selection (e.g. AUTO.TAKEOFF,
-                            // AUTO.LAND, MANUAL, etc. are transient and not user-selectable here).
+                            // selectable modes (_SELECTABLE_MODES); otherwise clear selection
+                            // (e.g. AUTO.TAKEOFF, AUTO.LAND, MANUAL, etc. are transient and not
+                            // user-selectable here).
                             let shown = _SELECTABLE_MODES.indexOf(message.mode) >= 0 ? message.mode : null;
                             highlight_mode_button(shown);
                         }

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -109,6 +109,32 @@ class Duckiedrone_Control extends BlockRenderer {
         $arming_service = $args['arming_service'] ?? self::$ARGUMENTS['arming_service']['default'];
         $legacy_set_mode_service = trim($args['service_set_mode'] ?? '');
         ?>
+        <style type="text/css">
+            #<?php echo $id ?> .rc-gimbal {
+                position: relative;
+                width: 130px; height: 130px;
+                margin: 2px auto;
+                border: 2px solid #999;
+                border-radius: 10px;
+                background: #f2f2f2;
+                touch-action: none;
+                box-sizing: border-box;
+            }
+            #<?php echo $id ?> .rc-gimbal .rc-crosshair {
+                position: absolute; left: 50%; top: 50%;
+                width: 8px; height: 8px; margin-left: -4px; margin-top: -4px;
+                border-radius: 50%; background: #ccc;
+            }
+            #<?php echo $id ?> .rc-gimbal .rc-knob {
+                position: absolute;
+                width: 36px; height: 36px;
+                margin-left: -18px; margin-top: -18px;
+                border-radius: 50%;
+                background: #00AA00;
+                border: 2px solid #003300;
+                pointer-events: none;
+            }
+        </style>
         <table class="resizable" style="height: 100%">
             <tr style="height: 20px; font-weight: bold">
                 <td class="col-md-1">
@@ -120,11 +146,31 @@ class Duckiedrone_Control extends BlockRenderer {
                 <td class="col-md-6 text-left">
                     Intensity
                 </td>
-                <td rowspan="5" class="col-md-2 text-center" style="padding: 0">
-                    <canvas id="drone_control_commands_joy_keys" width="150px" height="150px"></canvas>
+                <!-- RC Mode 2 layout: left stick = throttle (up/down) + yaw (left/right),
+                     right stick = pitch (up/down) + roll (left/right). -->
+                <td rowspan="5" class="text-center" style="padding: 0 4px; vertical-align: top">
+                    <div style="font-size:8pt; font-weight:bold;">&minus; yaw +</div>
+                    <div style="display:flex; justify-content:center; align-items:stretch;">
+                        <div style="display:flex; flex-direction:column; justify-content:space-between; align-items:center; font-size:8pt; font-weight:bold; padding:2px;">
+                            <span>+</span>
+                            <span style="writing-mode:vertical-rl; text-orientation:mixed;">throttle</span>
+                            <span>0</span>
+                        </div>
+                        <div id="<?php echo $id ?>_rc_left" class="rc-gimbal"><div class="rc-crosshair"></div></div>
+                    </div>
+                    <div style="font-size:8pt;">THR: <span id="<?php echo $id ?>_rc_thr_val">0</span></div>
                 </td>
-                <td rowspan="5" class="col-md-2 text-center" style="padding: 0">
-                    <div id="drone_control_commands_joy_stick" style="width:160px;height:160px;margin:0;"></div>
+                <td rowspan="5" class="text-center" style="padding: 0 4px; vertical-align: top">
+                    <div style="font-size:8pt; font-weight:bold;">&minus; roll +</div>
+                    <div style="display:flex; justify-content:center; align-items:stretch;">
+                        <div style="display:flex; flex-direction:column; justify-content:space-between; align-items:center; font-size:8pt; font-weight:bold; padding:2px;">
+                            <span>+</span>
+                            <span style="writing-mode:vertical-rl; text-orientation:mixed;">pitch</span>
+                            <span>&minus;</span>
+                        </div>
+                        <div id="<?php echo $id ?>_rc_right" class="rc-gimbal"><div class="rc-crosshair"></div></div>
+                    </div>
+                    <div style="font-size:8pt;">&nbsp;</div>
                 </td>
             </tr>
             <?php
@@ -182,8 +228,6 @@ class Duckiedrone_Control extends BlockRenderer {
         
         <!-- Include ROS -->
         <script src="<?php echo Core::getJSscriptURL('rosdb.js', 'ros') ?>"></script>
-        <!-- Include Joy library -->
-        <script src="<?php echo Core::getJSscriptURL('joy.js', 'duckietown_duckiedrone') ?>"></script>
 
         <script type="text/javascript">
             const CONST_YAW_DELTA = 90;
@@ -194,47 +238,82 @@ class Duckiedrone_Control extends BlockRenderer {
             const CONST_JOY_YAW_DEADBAND = 20;
             const CONST_MAX_ROLL_PITCH = <?php echo $args['max_roll_pitch'] ?? self::$ARGUMENTS['max_roll_pitch']['default'] ?>;
             
-            function drawArrow(ctx, fromx, fromy, tox, toy, arrowWidth, color) {
-                //variables to be used when creating the arrow
-                var headlen = 10;
-                var angle = Math.atan2(toy - fromy, tox - fromx);
-                
-                ctx.save();
-                ctx.strokeStyle = color;
-                
-                //starting path of the arrow from the start square to the end square and drawing the stroke
-                ctx.beginPath();
-                ctx.moveTo(fromx, fromy);
-                ctx.lineTo(tox, toy);
-                ctx.lineWidth = arrowWidth;
-                ctx.stroke();
-                
-                //starting a new path from the head of the arrow to one of the sides of the point
-                ctx.beginPath();
-                ctx.moveTo(tox, toy);
-                ctx.lineTo(
-                    tox - headlen * Math.cos(angle - Math.PI / 7),
-                    toy - headlen * Math.sin(angle - Math.PI / 7)
-                );
-                
-                //path from the side point of the arrow, to the other side point
-                ctx.lineTo(
-                    tox - headlen * Math.cos(angle + Math.PI / 7),
-                    toy - headlen * Math.sin(angle + Math.PI / 7)
-                );
-                
-                //path from the side point back to the tip of the arrow, and then again to the opposite side point
-                ctx.lineTo(tox, toy);
-                ctx.lineTo(
-                    tox - headlen * Math.cos(angle - Math.PI / 7),
-                    toy - headlen * Math.sin(angle - Math.PI / 7)
-                );
-                
-                //draws the paths created above
-                ctx.stroke();
-                ctx.restore();
+            // A minimal RC-style gimbal: a draggable knob in a square pad, with
+            // independent auto-centering per axis. Reports x and y in [-100, 100]
+            // (y is positive-up). Uses Pointer Events, so a single mouse or several
+            // touch points (one thumb per gimbal) work the same way.
+            class VirtualStick {
+                constructor(containerId, opts) {
+                    opts = opts || {};
+                    this.autoCenterX = opts.autoCenterX !== false;   // default: springs to center
+                    this.autoCenterY = opts.autoCenterY !== false;
+                    this.initialX = (typeof opts.initialX === 'number') ? opts.initialX : 0;
+                    this.initialY = (typeof opts.initialY === 'number') ? opts.initialY : 0;
+                    this.onChange = opts.onChange || function () {};
+                    this.x = this.initialX;
+                    this.y = this.initialY;
+
+                    this.container = document.getElementById(containerId);
+                    this.knob = document.createElement('div');
+                    this.knob.className = 'rc-knob';
+                    this.container.appendChild(this.knob);
+
+                    this.dragging = false;
+                    let self = this;
+                    this.container.addEventListener('pointerdown', function (e) {
+                        self.dragging = true;
+                        try { self.container.setPointerCapture(e.pointerId); } catch (_) {}
+                        self.knob.style.transition = 'none';
+                        self._update(e);
+                    });
+                    this.container.addEventListener('pointermove', function (e) {
+                        if (self.dragging) self._update(e);
+                    });
+                    let release = function (e) {
+                        if (!self.dragging) return;
+                        self.dragging = false;
+                        try { self.container.releasePointerCapture(e.pointerId); } catch (_) {}
+                        self.knob.style.transition = 'left 0.08s ease-out, top 0.08s ease-out';
+                        if (self.autoCenterX) self.x = 0;   // e.g. yaw / roll / pitch spring back
+                        if (self.autoCenterY) self.y = 0;   // throttle does NOT (holds where left)
+                        self._render();
+                        self.onChange(self.x, self.y);
+                    };
+                    this.container.addEventListener('pointerup', release);
+                    this.container.addEventListener('pointercancel', release);
+
+                    this._render();
+                }
+
+                _metrics() {
+                    let r = this.container.getBoundingClientRect();
+                    let size = Math.min(r.width, r.height);
+                    return { size: size, maxR: size / 2 - 4,
+                             cx: r.left + r.width / 2, cy: r.top + r.height / 2 };
+                }
+
+                _update(e) {
+                    let m = this._metrics();
+                    if (m.maxR <= 0) return;
+                    let dx = Math.max(-m.maxR, Math.min(m.maxR, e.clientX - m.cx));
+                    let dy = Math.max(-m.maxR, Math.min(m.maxR, e.clientY - m.cy));
+                    this.x = Math.round(dx / m.maxR * 100);
+                    this.y = Math.round(-dy / m.maxR * 100);   // screen-down is negative
+                    this._render();
+                    this.onChange(this.x, this.y);
+                }
+
+                _render() {
+                    let m = this._metrics();
+                    if (m.maxR <= 0) return;
+                    let half = m.size / 2;
+                    this.knob.style.left = (half + (this.x / 100) * m.maxR) + 'px';
+                    this.knob.style.top = (half - (this.y / 100) * m.maxR) + 'px';
+                }
+
+                setY(v) { this.y = v; this._render(); }
             }
-      
+
             // data types
             class JoyAxes {
                 constructor(left_right, front_back, cw_ccw, up_down) {
@@ -245,11 +324,13 @@ class Duckiedrone_Control extends BlockRenderer {
                 }
             
                 get manualControlMsg() {
+                    // PX4/MAVLink MANUAL_CONTROL: x-axis = pitch, y-axis = roll
+                    // (PX4 maps pitch = x/1000, roll = y/1000). Do NOT swap these.
                     return {
-                        x: this.roll,      // int16 [-1000, 1000]
-                        y: this.pitch,     // int16 [-1000, 1000]
+                        x: this.pitch,     // int16 [-1000, 1000], forward +
+                        y: this.roll,      // int16 [-1000, 1000], right +
                         z: this.throttle,  // int16 [-1000, 1000]
-                        r: this.yaw,       // int16 [-1000, 1000]
+                        r: this.yaw,       // int16 [-1000, 1000], clockwise +
                         buttons: 0         // uint16
                     };
                 }
@@ -342,22 +423,28 @@ class Duckiedrone_Control extends BlockRenderer {
                     });
                 }
             
-                let ctx = document.getElementById("drone_control_commands_joy_keys").getContext('2d');
-                
                 let roll_bar = $('#<?php echo $id ?> #drone_control_commands_bar_roll');
                 let pitch_bar = $('#<?php echo $id ?> #drone_control_commands_bar_pitch');
                 let yaw_bar = $('#<?php echo $id ?> #drone_control_commands_bar_yaw');
                 let throttle_bar = $('#<?php echo $id ?> #drone_control_commands_bar_throttle');
-                
-                let range = (<?php echo $args['max_value'] ?> - <?php echo $args['min_value'] ?>).toFixed(1);
-                
-                let joy_stick_data = new JoyXY(0, 0);
-                let joy_stick = new JoyStick('drone_control_commands_joy_stick', {}, function (data) {
-                    joy_stick_data.x = data.x;
-                    joy_stick_data.y = data.y;
+                let throttle_value_label = $('#<?php echo $id ?>_rc_thr_val');
+
+                // Two RC Mode-2 gimbals.
+                //   LEFT  — X = yaw (springs to center), Y = throttle (holds; rests at bottom = 0)
+                //   RIGHT — X = roll, Y = pitch (both spring to center)
+                let left_stick = new VirtualStick('<?php echo $id ?>_rc_left', {
+                    autoCenterX: true,
+                    autoCenterY: false,
+                    initialY: -100,   // bottom of travel -> throttle 0, so the FC can arm
+                    onChange: function (x, y) {
+                        throttle_value_label.text(Math.round((y + 100) * 5));
+                    }
                 });
-                let joy_keys = new Set([]);
-                
+                let right_stick = new VirtualStick('<?php echo $id ?>_rc_right', {
+                    autoCenterX: true,
+                    autoCenterY: true
+                });
+
                 let armed = false;
             
                 if (hasOverrideParams) {
@@ -391,13 +478,15 @@ class Duckiedrone_Control extends BlockRenderer {
                     throttle_rate: <?php echo 1000 / $args['frequency'] ?>
                 })).subscribe(function (message) {
                     // convert normalized values [-1000, 1000] to percentages [0, 100]
-                    let r = Math.floor(((message.x + 1000) / 2000) * 100);
-                    roll_bar.width("{0}%".format(r));
-                    let p = Math.floor(((message.y + 1000) / 2000) * 100);
+                    // MANUAL_CONTROL: x = pitch, y = roll (see manualControlMsg).
+                    let p = Math.floor(((message.x + 1000) / 2000) * 100);
                     pitch_bar.width("{0}%".format(p));
+                    let r = Math.floor(((message.y + 1000) / 2000) * 100);
+                    roll_bar.width("{0}%".format(r));
                     let y = Math.floor(((message.r + 1000) / 2000) * 100);
                     yaw_bar.width("{0}%".format(y));
-                    let t = Math.floor(((message.z + 1000) / 2000) * 100);
+                    // throttle z is 0..1000 (not centered like roll/pitch/yaw), so map straight to 0..100%
+                    let t = Math.max(0, Math.min(100, Math.floor((message.z / 1000) * 100)));
                     throttle_bar.width("{0}%".format(t));
                 });
                 
@@ -435,6 +524,10 @@ class Duckiedrone_Control extends BlockRenderer {
                 }
                 
                 function disarm_drone() {
+                    // Safety: drop throttle back to 0 on disarm, so the next arm starts from
+                    // zero throttle (the FC rejects arming at non-zero throttle).
+                    left_stick.setY(-100);
+                    throttle_value_label.text('0');
                     if (arming_srv !== null) {
                         let request = new ROSLIB.ServiceRequest({value: false});
                         arming_srv.callService(request, (_) => {});
@@ -448,95 +541,34 @@ class Duckiedrone_Control extends BlockRenderer {
                     console.warn('No disarm service configured for Duckiedrone_Control.');
                 }
                 
-                function map_to_real(k_front, k_back, k_left, k_right) {
-                    let x = parseInt(joy_stick_data.x);
-                    let y = parseInt(joy_stick_data.y);
-                    // throttle: map joystick Y (-100 to 100) to [0, 1000]
-                    // y=-100 -> 0, y=0 -> 500, y=100 -> 1000
-                    let throttle = Math.round((y + 100) * 5);
-                    
-                    // deadzone for yaw
-                    if (Math.abs(x) < CONST_JOY_YAW_DEADBAND) x = 0;
-                    // yaw: map joystick X (-100 to 100) to [-1000, 1000]
-                    let yaw = Math.round(x * 10);
-                
-                    let k_pitch = 0;
-                    if (k_front) {
-                        k_pitch = 1;
-                    } else if (k_back) {
-                        k_pitch = -1;
-                    }
-                    // pitch: discrete values -CONST_MAX_ROLL_PITCH, 0, or CONST_MAX_ROLL_PITCH
-                    let pitch = k_pitch * CONST_MAX_ROLL_PITCH;
-                    
-                    let k_roll = 0;
-                    if (k_left) {
-                        k_roll = -1;
-                    } else if (k_right) {
-                        k_roll = 1;
-                    }
-                    // roll: discrete values -CONST_MAX_ROLL_PITCH, 0, or CONST_MAX_ROLL_PITCH
-                    let roll = k_roll * CONST_MAX_ROLL_PITCH;
-                    
+                function compute_axes() {
+                    // LEFT stick: X = yaw (with a small deadband), Y = throttle (0..1000, held).
+                    let yaw_raw = left_stick.x;
+                    if (Math.abs(yaw_raw) < CONST_JOY_YAW_DEADBAND) yaw_raw = 0;
+                    let yaw = Math.round(yaw_raw * 10);                    // -1000..1000
+                    let throttle = Math.round((left_stick.y + 100) * 5);   // 0..1000 (bottom..top)
+                    throttle = Math.max(0, Math.min(1000, throttle));
+
+                    // RIGHT stick: X = roll, Y = pitch, scaled to the configured max authority.
+                    let roll = Math.round((right_stick.x / 100) * CONST_MAX_ROLL_PITCH);
+                    let pitch = Math.round((right_stick.y / 100) * CONST_MAX_ROLL_PITCH);
+
                     return new JoyAxes(roll, pitch, yaw, throttle);
                 }
-                
-                $(document).on("keyup", (e) => {
-                    let key = e.key.toLowerCase();
-                    if (['w', 'a', 's', 'd', ' '].indexOf(key) >= 0 && armed) {
-                        e.preventDefault();
-                    }
-                    joy_keys.delete(key);
-                });
-                
+
+                // Spacebar remains an emergency disarm.
                 $(document).on("keydown", (e) => {
-                    let key = e.key.toLowerCase();
-                    if (['w', 'a', 's', 'd', ' '].indexOf(key) >= 0 && armed) {
+                    if (e.key === " " && armed) {
                         e.preventDefault();
-                    }
-                    if (key === " ") {
-                        // space -> disarms
                         console.log("Disarming drone...");
                         disarm_drone();
-                    } else {
-                        joy_keys.add(key);
                     }
                 });
-                
+
                 function main_loop() {
-                    let front = joy_keys.has("w");
-                    let back = joy_keys.has("s");
-                    let left = joy_keys.has("a");
-                    let right = joy_keys.has("d");
-                    
-                    let line_width = 20;
-                    let pos = {
-                        up: [50, 45, 50, 10],
-                        down: [50, 55, 50, 90],
-                        left: [45, 50, 10, 50],
-                        right: [55, 50, 90, 50],
-                    };
-                    let scale = 1.2;
-                    let offsetX = 20;
-                    let offsetY = 20;
-                    
-                    for (let k in pos) {
-                        pos[k] = pos[k].map(x => x * scale);
-                        pos[k][0] += offsetX;
-                        pos[k][2] += offsetX;
-                        pos[k][1] += offsetY;
-                        pos[k][3] += offsetY;
-                    }
-                    
-                    drawArrow(ctx, ...pos.up, line_width, front ? 'green' : 'gray');
-                    drawArrow(ctx, ...pos.down, line_width, back ? 'green' : 'gray');
-                    drawArrow(ctx, ...pos.left, line_width, left ? 'green' : 'gray');
-                    drawArrow(ctx, ...pos.right, line_width, right ? 'green' : 'gray');
-                    
-                    let joy_axes = map_to_real(front, back, left, right);
-                    publish_joy_cmd(joy_axes, {});
+                    publish_joy_cmd(compute_axes(), {});
                 }
-                
+
                 setInterval(main_loop, 50);
             });
         </script>

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -282,6 +282,12 @@ class Duckiedrone_Control extends BlockRenderer {
                     this.container.addEventListener('pointerup', release);
                     this.container.addEventListener('pointercancel', release);
 
+                    if (typeof ResizeObserver !== 'undefined') {
+                        new ResizeObserver(function () { self._render(); }).observe(this.container);
+                    } else {
+                        window.addEventListener('resize', function () { self._render(); });
+                    }
+
                     this._render();
                 }
 
@@ -329,7 +335,7 @@ class Duckiedrone_Control extends BlockRenderer {
                     return {
                         x: this.pitch,     // int16 [-1000, 1000], forward +
                         y: this.roll,      // int16 [-1000, 1000], right +
-                        z: this.throttle,  // int16 [-1000, 1000]
+                        z: this.throttle,  // int16 [0, 1000]
                         r: this.yaw,       // int16 [-1000, 1000], clockwise +
                         buttons: 0         // uint16
                     };


### PR DESCRIPTION
Dashboard's Mavros_Arming widget only exposes LOITER/ALTCTL/OFFBOARD as selectable flight modes, 
none of which this GPS-less airframe can reliably arm/hold in currently due to the unavailability of Altitude Data from the ToF Sensor.

Added a STABILIZED button to the mode selector in Duckiedrone_Arming.php (class Mavros_Arming), 
Wired to the existing mavros_msgs/SetMode service call already used for the other modes. 

Also modified the Joystick to start at 0 as expected by the FC, rather than the current default of 500, 
which prevents the FC from arming, stating error: Thrust too high