### PR TITLE
DTSW-8107-Add-Keyboard-Control-in-Dashboard-for-Thrust-Yaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `$id` is unique per widget instance; use it to namespace DOM ids and JS vari
 |---|---|---|
 | `Duckiedrone_Arming.php` | `Mavros_Arming` | ARM/DISARM toggle + flight-mode toggle (OFFBOARD/ALTITUDE) + kill switch + takeoff button. Talks to mavros services. |
 | `Duckiedrone_Altitude.php` | `Duckiedrone_Altitude` | Altitude plot for `/altitude_node/altitude` with a desired-height overlay and dynamic Y-axis scaling based on live samples. |
-| `Duckiedrone_Control.php` | `Duckiedrone_Control` | Virtual joystick publishing to `/mavros/manual_control/send`, reading `/mavros/state`, with optional legacy override params for older fly-commands mux setups. |
+| `Duckiedrone_Control.php` | `Duckiedrone_Control` | Virtual joystick plus full keyboard control publishing to `/mavros/manual_control/send`, reading `/mavros/state`, with optional legacy override params for older fly-commands mux setups. Keyboard: `w/a/s/d` = pitch/roll, arrows `↑↓` = throttle (two-stage ramp with a vertical thrust gauge), arrows `←→` = yaw, `space` = disarm. |
 | `Duckiedrone_Heartbeat.php` | `Duckiedrone_Heartbeat` | Single-topic heartbeat indicator. |
 | `Duckiedrone_Heartbeats_Monitor.php` | `Duckiedrone_Heartbeats_Monitor` | Multi-topic heartbeat grid for joystick / altitude / state_estimator / pid. |
 | `DuckietownMsgs_DroneMotorCommand.php` | `DuckietownMsgs_DroneMotorCommand` | Bar chart of the four motor PWM values. Reads legacy `flight_controller_node/motors` messages and falls back to `/mavros/rc/out` for PX4/MAVROS deployments. |
@@ -84,7 +84,7 @@ The default Duckiedrone mission currently renders these panels, in this order:
 | `Joystick Heartbeat` | `Duckiedrone_Heartbeat` | `~/joystick/heartbeat` | Robot-scoped heartbeat pulse. |
 | `Motors PWM` | `DuckietownMsgs_DroneMotorCommand` | `/mavros/rc/out` | Reads `mavros_msgs/RCOut` directly. |
 | `Heartbeats Monitor` | `Duckiedrone_Heartbeats_Monitor` | `~/joystick/heartbeat`, `~/altitude_node/heartbeat`, `~/state_estimator_node/heartbeat`, `~/pid_controller_node/heartbeat` | Aggregated liveness grid for the main companion nodes. |
-| `Remote Control` | `Duckiedrone_Control` | `/mavros/manual_control/send`, `/mavros/state` | Virtual joystick plus live command bars. |
+| `Remote Control` | `Duckiedrone_Control` | `/mavros/manual_control/send`, `/mavros/state` | Virtual joystick and keyboard control (WASD + arrows) plus live command bars and a thrust gauge. |
 | `Arm / Disarm` | `Mavros_Arming` | `/mavros/cmd/arming`, `/mavros/cmd/command`, `/mavros/set_mode`, `/mavros/state` | ARM/DISARM, flight mode, kill switch. |
 | `Altitude` | `Duckiedrone_Altitude` | `~/altitude_node/altitude`, `~/pid_controller_node/desired/height` | Tilt-corrected altitude with desired-height overlay. |
 | `Time-of-Flight` | `SensorMsgs_Range` | `~/bottom_tof_driver_node/range` | Shared `ros` package renderer in numeric mode. |

--- a/data/private/default_missions/duckietown_duckiedrone_missions/default.json
+++ b/data/private/default_missions/duckietown_duckiedrone_missions/default.json
@@ -58,7 +58,7 @@
             },
 			{
 				"shape": {
-					"rows": 2,
+					"rows": 3,
 					"cols": 8
 				},
 				"renderer": "Duckiedrone_Control",

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -117,8 +117,17 @@ class Duckiedrone_Control extends BlockRenderer {
                 <td class="col-md-1 text-center">
                     Override
                 </td>
-                <td class="col-md-6 text-left">
+                <td class="col-md-4 text-left">
                     Intensity
+                </td>
+                <td rowspan="5" class="col-md-1 text-center" style="padding: 0">
+                    <canvas id="drone_control_commands_throttle_gauge" width="50px" height="150px"></canvas>
+                    <div style="margin-top: 4px">
+                        <label for="drone_control_commands_hover_threshold" style="font-size: 10px; display: block; white-space: nowrap">Hover threshold</label>
+                        <input type="number" id="drone_control_commands_hover_threshold"
+                               min="0" max="1000" step="1"
+                               style="width: 60px; font-size: 11px; padding: 1px 3px">
+                    </div>
                 </td>
                 <td rowspan="5" class="col-md-2 text-center" style="padding: 0">
                     <canvas id="drone_control_commands_joy_keys" width="150px" height="150px"></canvas>
@@ -193,6 +202,12 @@ class Duckiedrone_Control extends BlockRenderer {
             
             const CONST_JOY_YAW_DEADBAND = 20;
             const CONST_MAX_ROLL_PITCH = <?php echo $args['max_roll_pitch'] ?? self::$ARGUMENTS['max_roll_pitch']['default'] ?>;
+
+            // Keyboard yaw/throttle (arrow keys). Tune per airframe.
+            const CONST_YAW_KEY_VALUE = 60;              // joystick-X magnitude while a yaw key is held (> deadband)
+            const CONST_THROTTLE_STEP_COARSE = 25;       // throttle units (z, [0,1000]) added per tick below the hover threshold
+            const CONST_THROTTLE_STEP_FINE = 10;         // throttle units per tick at/above the hover threshold (fine hover trim)
+            const CONST_DEFAULT_HOVER_THRESHOLD = 400;   // fallback until the user calibrates their own value below
             
             function drawArrow(ctx, fromx, fromy, tox, toy, arrowWidth, color) {
                 //variables to be used when creating the arrow
@@ -234,7 +249,55 @@ class Duckiedrone_Control extends BlockRenderer {
                 ctx.stroke();
                 ctx.restore();
             }
-      
+
+            // Vertical throttle gauge for the `z` command [0,1000]: fill height tracks
+            // current throttle, a red line marks the user-calibrated hover_threshold, and
+            // the fill turns green once z crosses it.
+            function drawThrottleGauge(gctx, z, hover_threshold) {
+                let W = gctx.canvas.width, H = gctx.canvas.height;
+                let pad = 4, barW = 22, labelH = 14;
+                let x0 = (W - barW) / 2, y0 = pad, barH = H - pad * 2 - labelH;
+                gctx.clearRect(0, 0, W, H);
+
+                let frac = Math.max(0, Math.min(1, z / 1000));
+                let aboveThresh = z >= hover_threshold;
+
+                // filled portion: grey while grounded, green once airborne
+                let fillH = barH * frac;
+                gctx.fillStyle = aboveThresh ? '#28a745' : '#888';
+                gctx.fillRect(x0, y0 + barH - fillH, barW, fillH);
+
+                // frame
+                gctx.strokeStyle = '#333';
+                gctx.lineWidth = 1;
+                gctx.strokeRect(x0, y0, barW, barH);
+
+                // tick marks every 25%
+                gctx.strokeStyle = '#bbb';
+                for (let f = 0.25; f < 1; f += 0.25) {
+                    let ty = y0 + barH - barH * f;
+                    gctx.beginPath();
+                    gctx.moveTo(x0, ty);
+                    gctx.lineTo(x0 + 4, ty);
+                    gctx.stroke();
+                }
+
+                // hover_threshold marker line
+                let thY = y0 + barH - barH * (hover_threshold / 1000);
+                gctx.strokeStyle = '#d9534f';
+                gctx.lineWidth = 2;
+                gctx.beginPath();
+                gctx.moveTo(x0 - 3, thY);
+                gctx.lineTo(x0 + barW + 3, thY);
+                gctx.stroke();
+
+                // z as a percentage of full throttle
+                gctx.fillStyle = '#000';
+                gctx.font = '11px monospace';
+                gctx.textAlign = 'center';
+                gctx.fillText(Math.round(frac * 100) + '%', W / 2, H - 2);
+            }
+
             // data types
             class JoyAxes {
                 constructor(left_right, front_back, cw_ccw, up_down) {
@@ -344,7 +407,8 @@ class Duckiedrone_Control extends BlockRenderer {
                 }
             
                 let ctx = document.getElementById("drone_control_commands_joy_keys").getContext('2d');
-                
+                let gauge_ctx = document.getElementById("drone_control_commands_throttle_gauge").getContext('2d');
+
                 let roll_bar = $('#<?php echo $id ?> #drone_control_commands_bar_roll');
                 let pitch_bar = $('#<?php echo $id ?> #drone_control_commands_bar_pitch');
                 let yaw_bar = $('#<?php echo $id ?> #drone_control_commands_bar_yaw');
@@ -360,8 +424,25 @@ class Duckiedrone_Control extends BlockRenderer {
                     joy_stick_data.y = data.y;
                 });
                 let joy_keys = new Set([]);
-                
+                let kb_yaw_prev = false; // true if a yaw key was held last tick (to recenter on release)
+
                 let armed = false;
+
+                // Hover threshold: the z value where this specific drone leaves the ground.
+                // Users find it by ramping throttle up with the keyboard and reading the
+                // gauge/bar, then typing it in here so the coarse->fine ramp switchover
+                // and the gauge threshold line line up with their airframe. Persisted per
+                // widget instance so it survives page reloads.
+                const hover_threshold_storage_key = 'drone_control_hover_threshold_<?php echo $id ?>';
+                let hover_threshold = Number(localStorage.getItem(hover_threshold_storage_key)) || CONST_DEFAULT_HOVER_THRESHOLD;
+                let hover_threshold_input = $('#<?php echo $id ?> #drone_control_commands_hover_threshold');
+                hover_threshold_input.val(hover_threshold);
+                hover_threshold_input.on('change', function () {
+                    let entered = Math.max(0, Math.min(1000, Number($(this).val()) || CONST_DEFAULT_HOVER_THRESHOLD));
+                    hover_threshold = entered;
+                    $(this).val(entered);
+                    localStorage.setItem(hover_threshold_storage_key, entered);
+                });
             
                 if (hasOverrideParams) {
                     $('#<?php echo $id ?> #drone_control_commands_override_roll').change(function() {
@@ -486,17 +567,23 @@ class Duckiedrone_Control extends BlockRenderer {
                     return new JoyAxes(roll, pitch, yaw, throttle);
                 }
                 
+                // Keys this widget owns for flight control. Always prevented from doing
+                // their default browser thing (space/arrows scroll the page) regardless
+                // of arm state, so the page never scrolls out from under the pilot.
+                const CONTROL_KEYS = ['w', 'a', 's', 'd', ' ',
+                    'arrowup', 'arrowdown', 'arrowleft', 'arrowright'];
+
                 $(document).on("keyup", (e) => {
                     let key = e.key.toLowerCase();
-                    if (['w', 'a', 's', 'd', ' '].indexOf(key) >= 0 && armed) {
+                    if (CONTROL_KEYS.indexOf(key) >= 0) {
                         e.preventDefault();
                     }
                     joy_keys.delete(key);
                 });
-                
+
                 $(document).on("keydown", (e) => {
                     let key = e.key.toLowerCase();
-                    if (['w', 'a', 's', 'd', ' '].indexOf(key) >= 0 && armed) {
+                    if (CONTROL_KEYS.indexOf(key) >= 0) {
                         e.preventDefault();
                     }
                     if (key === " ") {
@@ -513,7 +600,44 @@ class Duckiedrone_Control extends BlockRenderer {
                     let back = joy_keys.has("s");
                     let left = joy_keys.has("a");
                     let right = joy_keys.has("d");
-                    
+
+                    // keyboard yaw (arrows L/R) and throttle (arrows U/D) drive the joystick,
+                    // keeping joy_stick_data the single source of truth shared with the mouse.
+                    let yaw_left = joy_keys.has("arrowleft");
+                    let yaw_right = joy_keys.has("arrowright");
+                    let thr_up = joy_keys.has("arrowup");
+                    let thr_down = joy_keys.has("arrowdown");
+
+                    let new_x = Number(joy_stick_data.x);
+                    let new_y = Number(joy_stick_data.y);
+                    let update_stick = false;
+
+                    // throttle: ramp and hold (coarse below the hover threshold, fine above)
+                    if (thr_up || thr_down) {
+                        let z = (new_y + 100) * 5; // joystick-Y -> throttle [0,1000]
+                        let step = (z < hover_threshold)
+                            ? CONST_THROTTLE_STEP_COARSE : CONST_THROTTLE_STEP_FINE;
+                        z += thr_up ? step : -step;
+                        z = Math.max(0, Math.min(1000, z));
+                        new_y = z / 5 - 100;
+                        update_stick = true;
+                    }
+
+                    // yaw: momentary, recenters on release (like roll/pitch)
+                    let kb_yaw = yaw_left || yaw_right;
+                    if (kb_yaw) {
+                        new_x = yaw_left ? -CONST_YAW_KEY_VALUE : CONST_YAW_KEY_VALUE;
+                        update_stick = true;
+                    } else if (kb_yaw_prev) {
+                        new_x = 0;
+                        update_stick = true;
+                    }
+                    kb_yaw_prev = kb_yaw;
+
+                    if (update_stick) {
+                        joy_stick.SetPosition(new_x, new_y);
+                    }
+
                     let line_width = 20;
                     let pos = {
                         up: [50, 45, 50, 10],
@@ -541,6 +665,8 @@ class Duckiedrone_Control extends BlockRenderer {
                     
                     let joy_axes = map_to_real(front, back, left, right);
                     publish_joy_cmd(joy_axes, {});
+
+                    drawThrottleGauge(gauge_ctx, joy_axes.throttle, hover_threshold);
                 }
                 
                 setInterval(main_loop, 50);

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -207,7 +207,7 @@ class Duckiedrone_Control extends BlockRenderer {
             const CONST_YAW_KEY_VALUE = 60;              // joystick-X magnitude while a yaw key is held (> deadband)
             const CONST_THROTTLE_STEP_COARSE = 25;       // throttle units (z, [0,1000]) added per tick below the hover threshold
             const CONST_THROTTLE_STEP_FINE = 10;         // throttle units per tick at/above the hover threshold (fine hover trim)
-            const CONST_DEFAULT_HOVER_THRESHOLD = 400;   // fallback until the user calibrates their own value below
+            const CONST_DEFAULT_HOVER_THRESHOLD = 100;   // conservatively low until the user calibrates their own value below
             
             function drawArrow(ctx, fromx, fromy, tox, toy, arrowWidth, color) {
                 //variables to be used when creating the arrow

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -120,47 +120,65 @@ class Duckiedrone_Control extends BlockRenderer {
                 <td class="col-md-4 text-left">
                     Intensity
                 </td>
-                <td rowspan="5" class="col-md-1 text-center" style="padding: 0">
-                    <canvas id="drone_control_commands_throttle_gauge" width="50px" height="150px"></canvas>
-                    <div style="margin-top: 4px">
-                        <label for="drone_control_commands_hover_threshold" style="font-size: 10px; display: block; white-space: nowrap">Hover threshold</label>
+                <td rowspan="5" class="col-md-1 text-center" style="padding: 0; vertical-align: middle">
+                    <canvas id="drone_control_commands_throttle_gauge" width="56px" height="110px"></canvas>
+                    <div style="margin-top: 3px"
+                         data-toggle="tooltip" data-placement="top"
+                         title="The throttle where the drone lifts off. Below it throttle rises fast, above it rises slowly for fine control. Blue line on the gauge.">
+                        <label for="drone_control_commands_hover_threshold" style="display: block; font-size: 12px; margin: 0 0 1px; font-weight: normal">Hover</label>
                         <input type="number" id="drone_control_commands_hover_threshold"
                                min="0" max="1000" step="1"
-                               style="width: 60px; font-size: 11px; padding: 1px 3px">
+                               style="width: 56px; font-size: 13px; padding: 1px 3px">
+                    </div>
+                    <div style="margin-top: 5px"
+                         data-toggle="tooltip" data-placement="top"
+                         title="The most throttle allowed. The drone never goes above this, whatever the keyboard or joystick asks for. Red line on the gauge.">
+                        <label for="drone_control_commands_max_throttle" style="display: block; font-size: 12px; margin: 0 0 1px; font-weight: normal">Thrust Cap</label>
+                        <input type="number" id="drone_control_commands_max_throttle"
+                               min="0" max="1000" step="1"
+                               style="width: 56px; font-size: 13px; padding: 1px 3px">
                     </div>
                 </td>
-                <td rowspan="5" class="col-md-2 text-center" style="padding: 0">
-                    <canvas id="drone_control_commands_joy_keys" width="150px" height="150px"></canvas>
+                <td rowspan="5" class="col-md-2 text-center" style="padding: 0; vertical-align: middle">
+                    <canvas id="drone_control_commands_joy_keys" width="150px" height="134px"></canvas>
+                    <div style="font-size: 13px; color: #555">Roll / Pitch</div>
                 </td>
-                <td rowspan="5" class="col-md-2 text-center" style="padding: 0">
-                    <div id="drone_control_commands_joy_stick" style="width:160px;height:160px;margin:0;"></div>
+                <td rowspan="5" class="col-md-2 text-center" style="padding: 0; vertical-align: middle">
+                    <div id="drone_control_commands_joy_stick" style="width:120px;height:120px;margin:0 auto;"></div>
+                    <div style="font-size: 13px; color: #555">Yaw / Throttle</div>
                 </td>
             </tr>
             <?php
             $bars = [
                 [
                     "id" => "roll",
-                    "label" => "Roll"
+                    "label" => "Roll",
+                    "tooltip" => "Tilt left or right. Keys A and D."
                 ],
                 [
                     "id" => "pitch",
-                    "label" => "Pitch"
+                    "label" => "Pitch",
+                    "tooltip" => "Tilt forward or back. Keys W and S."
                 ],
                 [
                     "id" => "yaw",
-                    "label" => "Yaw"
+                    "label" => "Yaw",
+                    "tooltip" => "Turn left or right. Left and right arrow keys."
                 ],
                 [
                     "id" => "throttle",
-                    "label" => "Throttle"
+                    "label" => "Throttle",
+                    "tooltip" => "More or less thrust. Up and down arrow keys. Stays where it is left."
                 ],
             ];
             
             foreach ($bars as &$bar) {
                 ?>
                 <tr style="height: 20px">
-                    <td class="col-md-1" style="text-align: right">
-                        <p class=text-right" style="margin: 0"><?php echo $bar["label"] ?></p>
+                    <td class="col-md-1" style="text-align: right"
+                        data-toggle="tooltip" data-placement="top"
+                        title="<?php echo $bar["tooltip"] ?>">
+                        <p class="text-right" style="margin: 0"><?php echo $bar["label"] ?></p>
                     </td>
                     <td class="col-md-1">
                         <input type="checkbox"
@@ -187,6 +205,17 @@ class Duckiedrone_Control extends BlockRenderer {
                 <?php
             }
             ?>
+            <tr>
+                <td colspan="6" style="padding: 2px 4px 0; border-top: 1px solid #eee">
+                    <div style="font-size: 14px; color: #666; text-align: center; line-height: 1.5">
+                        <b>A</b> / <b>D</b> = Roll (Roll Left / Right)
+                        &nbsp;&middot;&nbsp; <b>W</b> / <b>S</b> = Pitch (Pitch Forward / Back)
+                        &nbsp;&middot;&nbsp; <b>&larr;</b> / <b>&rarr;</b> = Yaw (Yaw Left / Right)
+                        &nbsp;&middot;&nbsp; <b>&uarr;</b> / <b>&darr;</b> = Throttle (More / Less)
+                        &nbsp;&middot;&nbsp; <b>Space</b> = Disarm
+                    </div>
+                </td>
+            </tr>
         </table>
         
         <!-- Include ROS -->
@@ -208,6 +237,7 @@ class Duckiedrone_Control extends BlockRenderer {
             const CONST_THROTTLE_STEP_COARSE = 25;       // throttle units (z, [0,1000]) added per tick below the hover threshold
             const CONST_THROTTLE_STEP_FINE = 10;         // throttle units per tick at/above the hover threshold (fine hover trim)
             const CONST_DEFAULT_HOVER_THRESHOLD = 100;   // conservatively low until the user calibrates their own value below
+            const CONST_DEFAULT_MAX_THROTTLE = 500;      // hard ceiling on thrust; command can never exceed this (z, [0,1000])
             
             function drawArrow(ctx, fromx, fromy, tox, toy, arrowWidth, color) {
                 //variables to be used when creating the arrow
@@ -251,11 +281,12 @@ class Duckiedrone_Control extends BlockRenderer {
             }
 
             // Vertical throttle gauge for the `z` command [0,1000]: fill height tracks
-            // current throttle, a red line marks the user-calibrated hover_threshold, and
-            // the fill turns green once z crosses it.
-            function drawThrottleGauge(gctx, z, hover_threshold) {
+            // current throttle, a blue line marks the user-calibrated hover_threshold, a red
+            // line marks the max_throttle ceiling, and the fill turns green once z crosses
+            // the hover threshold.
+            function drawThrottleGauge(gctx, z, hover_threshold, max_throttle) {
                 let W = gctx.canvas.width, H = gctx.canvas.height;
-                let pad = 4, barW = 22, labelH = 14;
+                let pad = 4, barW = 26, labelH = 16;
                 let x0 = (W - barW) / 2, y0 = pad, barH = H - pad * 2 - labelH;
                 gctx.clearRect(0, 0, W, H);
 
@@ -282,18 +313,27 @@ class Duckiedrone_Control extends BlockRenderer {
                     gctx.stroke();
                 }
 
-                // hover_threshold marker line
+                // hover_threshold marker line (blue)
                 let thY = y0 + barH - barH * (hover_threshold / 1000);
-                gctx.strokeStyle = '#d9534f';
+                gctx.strokeStyle = '#337ab7';
                 gctx.lineWidth = 2;
                 gctx.beginPath();
                 gctx.moveTo(x0 - 3, thY);
                 gctx.lineTo(x0 + barW + 3, thY);
                 gctx.stroke();
 
+                // max_throttle ceiling line (red)
+                let ceilY = y0 + barH - barH * (max_throttle / 1000);
+                gctx.strokeStyle = '#d9534f';
+                gctx.lineWidth = 2;
+                gctx.beginPath();
+                gctx.moveTo(x0 - 3, ceilY);
+                gctx.lineTo(x0 + barW + 3, ceilY);
+                gctx.stroke();
+
                 // z as a percentage of full throttle
                 gctx.fillStyle = '#000';
-                gctx.font = '11px monospace';
+                gctx.font = '13px monospace';
                 gctx.textAlign = 'center';
                 gctx.fillText(Math.round(frac * 100) + '%', W / 2, H - 2);
             }
@@ -428,21 +468,56 @@ class Duckiedrone_Control extends BlockRenderer {
 
                 let armed = false;
 
+                // Settings persist per widget instance across page reloads. localStorage can
+                // throw (private browsing, sandboxed iframe, storage disabled), so both calls
+                // are wrapped: a storage failure must never stop the setup below, or the
+                // manual_control publish loop would die and the drone could not arm.
+                function load_setting(key, fallback) {
+                    try {
+                        return Number(localStorage.getItem(key)) || fallback;
+                    } catch (e) {
+                        return fallback;
+                    }
+                }
+                function save_setting(key, value) {
+                    try {
+                        localStorage.setItem(key, value);
+                    } catch (e) {}
+                }
+
                 // Hover threshold: the z value where this specific drone leaves the ground.
-                // Users find it by ramping throttle up with the keyboard and reading the
-                // gauge/bar, then typing it in here so the coarse->fine ramp switchover
-                // and the gauge threshold line line up with their airframe. Persisted per
-                // widget instance so it survives page reloads.
+                // Users find it by ramping throttle up and reading the gauge/bar, then typing
+                // it in so the coarse->fine ramp switchover and the gauge line match their
+                // airframe.
                 const hover_threshold_storage_key = 'drone_control_hover_threshold_<?php echo $id ?>';
-                let hover_threshold = Number(localStorage.getItem(hover_threshold_storage_key)) || CONST_DEFAULT_HOVER_THRESHOLD;
+                let hover_threshold = load_setting(hover_threshold_storage_key, CONST_DEFAULT_HOVER_THRESHOLD);
                 let hover_threshold_input = $('#<?php echo $id ?> #drone_control_commands_hover_threshold');
                 hover_threshold_input.val(hover_threshold);
                 hover_threshold_input.on('change', function () {
                     let entered = Math.max(0, Math.min(1000, Number($(this).val()) || CONST_DEFAULT_HOVER_THRESHOLD));
                     hover_threshold = entered;
                     $(this).val(entered);
-                    localStorage.setItem(hover_threshold_storage_key, entered);
+                    save_setting(hover_threshold_storage_key, entered);
                 });
+
+                // Max throttle: hard ceiling on the z command. Thrust can never be commanded
+                // above this, whatever the keyboard ramp or joystick asks for.
+                const max_throttle_storage_key = 'drone_control_max_throttle_<?php echo $id ?>';
+                let max_throttle = load_setting(max_throttle_storage_key, CONST_DEFAULT_MAX_THROTTLE);
+                let max_throttle_input = $('#<?php echo $id ?> #drone_control_commands_max_throttle');
+                max_throttle_input.val(max_throttle);
+                max_throttle_input.on('change', function () {
+                    let entered = Math.max(0, Math.min(1000, Number($(this).val()) || CONST_DEFAULT_MAX_THROTTLE));
+                    max_throttle = entered;
+                    $(this).val(entered);
+                    save_setting(max_throttle_storage_key, entered);
+                });
+
+                // Native title tooltips always work; upgrade to Bootstrap tooltips when the
+                // plugin is present. Guarded so a missing plugin cannot break setup.
+                try {
+                    $('#<?php echo $id ?> [data-toggle="tooltip"]').tooltip();
+                } catch (e) {}
             
                 if (hasOverrideParams) {
                     $('#<?php echo $id ?> #drone_control_commands_override_roll').change(function() {
@@ -539,7 +614,8 @@ class Duckiedrone_Control extends BlockRenderer {
                     let y = Number(joy_stick_data.y);
                     // throttle: map joystick Y (-100 to 100) to [0, 1000]
                     // y=-100 -> 0, y=0 -> 500, y=100 -> 1000
-                    let throttle = Math.round((y + 100) * 5);
+                    // then apply the hard ceiling so nothing published can exceed it
+                    let throttle = Math.min(max_throttle, Math.round((y + 100) * 5));
                     
                     // deadzone for yaw
                     if (Math.abs(x) < CONST_JOY_YAW_DEADBAND) x = 0;
@@ -618,7 +694,7 @@ class Duckiedrone_Control extends BlockRenderer {
                         let step = (z < hover_threshold)
                             ? CONST_THROTTLE_STEP_COARSE : CONST_THROTTLE_STEP_FINE;
                         z += thr_up ? step : -step;
-                        z = Math.max(0, Math.min(1000, z));
+                        z = Math.max(0, Math.min(max_throttle, z));
                         new_y = z / 5 - 100;
                         update_stick = true;
                     }
@@ -666,7 +742,7 @@ class Duckiedrone_Control extends BlockRenderer {
                     let joy_axes = map_to_real(front, back, left, right);
                     publish_joy_cmd(joy_axes, {});
 
-                    drawThrottleGauge(gauge_ctx, joy_axes.throttle, hover_threshold);
+                    drawThrottleGauge(gauge_ctx, joy_axes.throttle, hover_threshold, max_throttle);
                 }
                 
                 setInterval(main_loop, 50);


### PR DESCRIPTION
Add keyboard control for yaw and thrust (DTSW-8107)

↑ / ↓ — throttle. 

Ramps while held instead of jumping straight to a value, and holds the last position on release so you can still hover hands-off. Steps 25 units/tick below the hover threshold, 10 units/tick above it, so it's coarse getting off the ground and finer once you're airborne.

← / → — yaw.
Momentary, like roll/pitch, snaps back to zero on release.

Added a "hover threshold" input next to a small vertical thrust gauge, type in the throttle value where your specific airframe leaves the ground, and the ramp's coarse/fine switchover and the gauge's threshold line both use it. 

Saved in localStorage per widget so it doesn't reset every page load. 
Defaults to 100, low enough that nobody takes off at full ramp speed before they've calibrated it.

Also fixed a bug where space/arrow keys would scroll the page instead of being consumed by the widget while disarmed.