### PR TITLE
DTSW-8143-Refactor-Dashboard-UI

### DIFF
--- a/data/private/default_missions/duckietown_duckiedrone_missions/default.json
+++ b/data/private/default_missions/duckietown_duckiedrone_missions/default.json
@@ -144,7 +144,7 @@
                     "ros_hostname": "",
                     "topic": "/mavros/imu/data",
                     "gyro_service": "/px4_calibration/calibrate_gyro",
-                    "accel_service": "/px4_calibration/calibrate_accel",
+                    "level_service": "/px4_calibration/calibrate_level",
                     "status_topic": "/px4_calibration/status",
                     "fps": 5
                 }

--- a/js/joy.js
+++ b/js/joy.js
@@ -123,19 +123,9 @@ var JoyStick = (function(container, parameters, callback)
     var movedX = centerX + ((Math.max(-100, Math.min(100, initialX)) / 100) * maxMoveStick);
     var movedY = centerY - ((Math.max(-100, Math.min(100, initialY)) / 100) * maxMoveStick);
 
-    // Check if the device support the touch or not
-    if("ontouchstart" in document.documentElement)
-    {
-        canvas.addEventListener("touchstart", onTouchStart, false);
-        document.addEventListener("touchmove", onTouchMove, false);
-        document.addEventListener("touchend", onTouchEnd, false);
-    }
-    else
-    {
-        canvas.addEventListener("mousedown", onMouseDown, false);
-        document.addEventListener("mousemove", onMouseMove, false);
-        document.addEventListener("mouseup", onMouseUp, false);
-    }
+    // Pointer/touch control disabled — the drone is driven from the keyboard only.
+    // The stick still renders and reflects programmatic state, but does not accept
+    // mouse or touch input.
     // Draw the object
     drawExternal();
     drawInternal();

--- a/modules/renderers/blocks/Duckiedrone_Arming.php
+++ b/modules/renderers/blocks/Duckiedrone_Arming.php
@@ -137,19 +137,10 @@ class Mavros_Arming extends BlockRenderer {
                 <div id="mode_status_message" class="status-msg"></div>
             </div>
 
-            <!-- Col 3 — Stacked TAKEOFF / KILL buttons -->
+            <!-- Col 3 — KILL button -->
             <div class="col">
                 <div class="col-label">ACTIONS</div>
                 <div class="btn-stack">
-                    <button type="button"
-                            class="btn btn-success btn-xs arming-btn"
-                            id="drone_takeoff_button"
-                            disabled
-                            title="Takeoff disabled — use manual altitude control"
-                            style="opacity: 0.5;">
-                        <i class="fa fa-plane" style="margin-right: 3px;"></i>
-                        TAKEOFF
-                    </button>
                     <button type="button"
                             class="btn btn-danger btn-xs arming-btn"
                             id="drone_kill_switch_button"
@@ -175,13 +166,10 @@ class Mavros_Arming extends BlockRenderer {
             let _MODE_LOITER = 'AUTO.LOITER';
             let _MODE_ALTITUDE = 'ALTCTL';
             let _MODE_OFFBOARD = 'OFFBOARD';
-            let _MODE_AUTO_TAKEOFF = 'AUTO.TAKEOFF';
-            let _MODE_AUTO_LAND = 'AUTO.LAND';
             let _SELECTABLE_MODES = [_MODE_STABILIZED, _MODE_LOITER, _MODE_ALTITUDE, _MODE_OFFBOARD];
 
             // Track states
             let isArmed = false;
-            let isFlying = false;
             let currentMode = null;   // unknown until first /mavros/state message
             let _syncing = false;     // true while programmatically updating toggles — suppress change handlers
 
@@ -227,107 +215,6 @@ class Mavros_Arming extends BlockRenderer {
                     });
                 }
 
-                function initiate_takeoff() {
-                    console.log("Initiating takeoff sequence...");
-                    
-                    // Disable the takeoff button during the process
-                    let takeoff_btn = $('#<?php echo $id ?> #drone_takeoff_button');
-                    takeoff_btn.prop('disabled', true);
-                    takeoff_btn.html('<i class="fa fa-spinner fa-spin" style="margin-right: 5px;"></i>TAKING OFF...');
-                    
-                    // Step 1: Set mode to AUTO.TAKEOFF
-                    set_mode(_MODE_AUTO_TAKEOFF, function(mode_response) {
-                        console.log("Set mode response:", mode_response);
-                        if (mode_response.mode_sent) {
-                            console.log("Mode set to AUTO.TAKEOFF successfully");
-                            
-                            // Step 2: Arm the drone to initiate takeoff
-                            // Increased delay to allow flight controller to process mode change
-                            setTimeout(function() {
-                                console.log("Calling arming service...");
-                                let request = new ROSLIB.ServiceRequest({value: true});
-                                arming_srv.callService(request, function(arm_response) {
-                                    console.log("Arming for takeoff response:", arm_response);
-                                    console.log("Arming success:", arm_response.success);
-                                    console.log("Arming result code:", arm_response.result);
-                                    
-                                    if (arm_response.success) {
-                                        console.log("Takeoff initiated successfully!");
-                                        isArmed = true;
-                                        isFlying = true;
-                                        
-                                        // Change button to LAND mode after 3 seconds
-                                        setTimeout(function() {
-                                            takeoff_btn.prop('disabled', false);
-                                            takeoff_btn.removeClass('btn-success').addClass('btn-warning');
-                                            takeoff_btn.html('<i class="fa fa-chevron-down" style="margin-right: 5px;"></i>LAND');
-                                        }, 3000);
-                                    } else {
-                                        console.error("Failed to arm for takeoff. Result code:", arm_response.result);
-                                        takeoff_btn.prop('disabled', false);
-                                        takeoff_btn.html('<i class="fa fa-exclamation-triangle" style="margin-right: 5px;"></i>FAILED');
-                                        
-                                        // Reset button text after 2 seconds
-                                        setTimeout(function() {
-                                            takeoff_btn.html('<i class="fa fa-plane" style="margin-right: 5px;"></i>TAKEOFF');
-                                        }, 2000);
-                                    }
-                                }, function(error) {
-                                    console.error("Arming service call error:", error);
-                                    takeoff_btn.prop('disabled', false);
-                                    takeoff_btn.html('<i class="fa fa-exclamation-triangle" style="margin-right: 5px;"></i>ERROR');
-                                    setTimeout(function() {
-                                        takeoff_btn.html('<i class="fa fa-plane" style="margin-right: 5px;"></i>TAKEOFF');
-                                    }, 2000);
-                                });
-                            }, 1500); // Increased delay from 500ms to 1500ms
-                        } else {
-                            console.error("Failed to set mode to AUTO.TAKEOFF");
-                            takeoff_btn.prop('disabled', false);
-                            takeoff_btn.html('<i class="fa fa-exclamation-triangle" style="margin-right: 5px;"></i>FAILED');
-                            
-                            // Reset button text after 2 seconds
-                            setTimeout(function() {
-                                takeoff_btn.html('<i class="fa fa-plane" style="margin-right: 5px;"></i>TAKEOFF');
-                            }, 2000);
-                        }
-                    });
-                }
-
-                function initiate_landing() {
-                    console.log("Initiating landing sequence...");
-                    
-                    // Disable the land button during the process
-                    let land_btn = $('#<?php echo $id ?> #drone_takeoff_button');
-                    land_btn.prop('disabled', true);
-                    land_btn.html('<i class="fa fa-spinner fa-spin" style="margin-right: 5px;"></i>LANDING...');
-                    
-                    // Set mode to AUTO.LAND
-                    set_mode(_MODE_AUTO_LAND, function(mode_response) {
-                        if (mode_response.mode_sent) {
-                            console.log("Mode set to AUTO.LAND successfully");
-                            isFlying = false;
-                            
-                            // Change button back to TAKEOFF mode after 2 seconds
-                            setTimeout(function() {
-                                land_btn.prop('disabled', false);
-                                land_btn.removeClass('btn-warning').addClass('btn-success');
-                                land_btn.html('<i class="fa fa-plane" style="margin-right: 5px;"></i>TAKEOFF');
-                            }, 2000);
-                        } else {
-                            console.error("Failed to set mode to AUTO.LAND");
-                            land_btn.prop('disabled', false);
-                            land_btn.html('<i class="fa fa-exclamation-triangle" style="margin-right: 5px;"></i>FAILED');
-                            
-                            // Reset button text after 2 seconds
-                            setTimeout(function() {
-                                land_btn.removeClass('btn-success').addClass('btn-warning');
-                                land_btn.html('<i class="fa fa-chevron-down" style="margin-right: 5px;"></i>LAND');
-                            }, 2000);
-                        }
-                    });
-                }
-
                 function emergency_kill() {
                     console.log("EMERGENCY KILL SWITCH ACTIVATED!");
                     
@@ -355,14 +242,10 @@ class Mavros_Arming extends BlockRenderer {
                         if (response.success) {
                             console.log("Emergency kill successful!");
                             isArmed = false;
-                            isFlying = false;
-                            
+
                             // Reset states
                             $('#<?php echo $id ?> #drone_arming_toggle').bootstrapToggle('off');
-                            let takeoff_btn = $('#<?php echo $id ?> #drone_takeoff_button');
-                            takeoff_btn.removeClass('btn-warning').addClass('btn-success');
-                            takeoff_btn.html('<i class="fa fa-plane" style="margin-right: 5px;"></i>TAKEOFF');
-                            
+
                             // Re-enable kill button
                             setTimeout(function() {
                                 kill_btn.prop('disabled', false);
@@ -523,17 +406,6 @@ class Mavros_Arming extends BlockRenderer {
                         }
                     });
                 });
-
-                // Takeoff button disabled - commented out
-                // $('#<?php echo $id ?> #drone_takeoff_button').off().click(function() {
-                //     if (isFlying) {
-                //         console.log("Land button clicked");
-                //         initiate_landing();
-                //     } else {
-                //         console.log("Takeoff button clicked");
-                //         initiate_takeoff();
-                //     }
-                // });
 
                 $('#<?php echo $id ?> #drone_kill_switch_button').off().click(function() {
                     console.log("Kill switch button clicked");

--- a/modules/renderers/blocks/Duckiedrone_Arming.php
+++ b/modules/renderers/blocks/Duckiedrone_Arming.php
@@ -127,9 +127,11 @@ class Mavros_Arming extends BlockRenderer {
                 <div class="btn-group-vertical btn-group-xs" role="group" id="drone_mode_selector">
                     <button type="button" class="btn btn-default" data-mode="STABILIZED"
                             title="PX4 STABILIZED — manual attitude control that self-levels; needs no GPS or altitude estimate. Use this for manual flight.">STABILIZED</button>
-                    <button type="button" class="btn btn-default" data-mode="AUTO.LOITER"
+                    <!-- LOITER / ALTITUDE hidden for now (not in current LX scope); kept in
+                         the DOM + JS wiring below so they can be re-enabled later. -->
+                    <button type="button" class="btn btn-default" data-mode="AUTO.LOITER" style="display: none"
                             title="PX4 AUTO.LOITER — position/altitude hold, safe armable default">LOITER</button>
-                    <button type="button" class="btn btn-default" data-mode="ALTCTL"
+                    <button type="button" class="btn btn-default" data-mode="ALTCTL" style="display: none"
                             title="PX4 ALTCTL — manual stick with altitude hold">ALTITUDE</button>
                     <button type="button" class="btn btn-default" data-mode="OFFBOARD"
                             title="PX4 OFFBOARD — external setpoints">OFFBOARD</button>

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -477,7 +477,11 @@ class Duckiedrone_Control extends BlockRenderer {
                 // manual_control publish loop would die and the drone could not arm.
                 function load_setting(key, fallback) {
                     try {
-                        return Number(localStorage.getItem(key)) || fallback;
+                        // Avoid `Number(...) || fallback`: it drops a valid stored 0.
+                        let raw = localStorage.getItem(key);
+                        if (raw === null || raw === '') return fallback;
+                        let value = Number(raw);
+                        return isNaN(value) ? fallback : value;
                     } catch (e) {
                         return fallback;
                     }

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -233,7 +233,10 @@ class Duckiedrone_Control extends BlockRenderer {
             const CONST_MAX_ROLL_PITCH = <?php echo $args['max_roll_pitch'] ?? self::$ARGUMENTS['max_roll_pitch']['default'] ?>;
 
             // Keyboard yaw/throttle (arrow keys). Tune per airframe.
-            const CONST_YAW_KEY_VALUE = 60;              // joystick-X magnitude while a yaw key is held (> deadband)
+            // joystick-X magnitude while a yaw key is held. Chosen so the resulting yaw
+            // command (map_to_real: yaw = x * 10) equals the roll/pitch command magnitude
+            // (CONST_MAX_ROLL_PITCH), keeping the yaw rate matched to the roll/pitch rate.
+            const CONST_YAW_KEY_VALUE = CONST_MAX_ROLL_PITCH / 10;
             const CONST_THROTTLE_STEP_COARSE = 25;       // throttle units (z, [0,1000]) added per tick below the hover threshold
             const CONST_THROTTLE_STEP_FINE = 10;         // throttle units per tick at/above the hover threshold (fine hover trim)
             const CONST_DEFAULT_HOVER_THRESHOLD = 100;   // conservatively low until the user calibrates their own value below

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -471,7 +471,7 @@ class Duckiedrone_Control extends BlockRenderer {
 
                 let armed = false;
 
-                // Settings persist per widget instance across page reloads. localStorage can
+                // Settings persist per ROSbridge host across page reloads. localStorage can
                 // throw (private browsing, sandboxed iframe, storage disabled), so both calls
                 // are wrapped: a storage failure must never stop the setup below, or the
                 // manual_control publish loop would die and the drone could not arm.
@@ -496,7 +496,7 @@ class Duckiedrone_Control extends BlockRenderer {
                 // Users find it by ramping throttle up and reading the gauge/bar, then typing
                 // it in so the coarse->fine ramp switchover and the gauge line match their
                 // airframe.
-                const hover_threshold_storage_key = 'drone_control_hover_threshold_<?php echo $id ?>';
+                const hover_threshold_storage_key = 'drone_control_hover_threshold_<?php echo $ros_hostname ?>';
                 // Stored/used internally as a z value in [0,1000]; shown and entered as a
                 // percentage of full thrust (0-100%). % <-> z: z = pct * 10.
                 let hover_threshold = load_setting(hover_threshold_storage_key, CONST_DEFAULT_HOVER_THRESHOLD);
@@ -513,7 +513,7 @@ class Duckiedrone_Control extends BlockRenderer {
 
                 // Max throttle: hard ceiling on the z command. Thrust can never be commanded
                 // above this, whatever the keyboard ramp or joystick asks for.
-                const max_throttle_storage_key = 'drone_control_max_throttle_<?php echo $id ?>';
+                const max_throttle_storage_key = 'drone_control_max_throttle_<?php echo $ros_hostname ?>';
                 // Same convention as the hover threshold: internal z in [0,1000], shown and
                 // entered as a percentage of full thrust (0-100%).
                 let max_throttle = load_setting(max_throttle_storage_key, CONST_DEFAULT_MAX_THROTTLE);

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -125,17 +125,17 @@ class Duckiedrone_Control extends BlockRenderer {
                     <div style="margin-top: 3px"
                          data-toggle="tooltip" data-placement="top"
                          title="The throttle where the drone lifts off. Below it throttle rises fast, above it rises slowly for fine control. Blue line on the gauge.">
-                        <label for="drone_control_commands_hover_threshold" style="display: block; font-size: 12px; margin: 0 0 1px; font-weight: normal">Hover</label>
+                        <label for="drone_control_commands_hover_threshold" style="display: block; font-size: 12px; margin: 0 0 1px; font-weight: normal">Hover %</label>
                         <input type="number" id="drone_control_commands_hover_threshold"
-                               min="0" max="1000" step="1"
+                               min="0" max="100" step="1"
                                style="width: 56px; font-size: 13px; padding: 1px 3px">
                     </div>
                     <div style="margin-top: 5px"
                          data-toggle="tooltip" data-placement="top"
                          title="The most throttle allowed. The drone never goes above this, whatever the keyboard or joystick asks for. Red line on the gauge.">
-                        <label for="drone_control_commands_max_throttle" style="display: block; font-size: 12px; margin: 0 0 1px; font-weight: normal">Thrust Cap</label>
+                        <label for="drone_control_commands_max_throttle" style="display: block; font-size: 12px; margin: 0 0 1px; font-weight: normal">Thrust Cap %</label>
                         <input type="number" id="drone_control_commands_max_throttle"
-                               min="0" max="1000" step="1"
+                               min="0" max="100" step="1"
                                style="width: 56px; font-size: 13px; padding: 1px 3px">
                     </div>
                 </td>
@@ -237,7 +237,7 @@ class Duckiedrone_Control extends BlockRenderer {
             const CONST_THROTTLE_STEP_COARSE = 25;       // throttle units (z, [0,1000]) added per tick below the hover threshold
             const CONST_THROTTLE_STEP_FINE = 10;         // throttle units per tick at/above the hover threshold (fine hover trim)
             const CONST_DEFAULT_HOVER_THRESHOLD = 100;   // conservatively low until the user calibrates their own value below
-            const CONST_DEFAULT_MAX_THROTTLE = 500;      // hard ceiling on thrust; command can never exceed this (z, [0,1000])
+            const CONST_DEFAULT_MAX_THROTTLE = 400;      // hard ceiling on thrust (z, [0,1000]); shown to the user as 40%
             
             function drawArrow(ctx, fromx, fromy, tox, toy, arrowWidth, color) {
                 //variables to be used when creating the arrow
@@ -490,27 +490,35 @@ class Duckiedrone_Control extends BlockRenderer {
                 // it in so the coarse->fine ramp switchover and the gauge line match their
                 // airframe.
                 const hover_threshold_storage_key = 'drone_control_hover_threshold_<?php echo $id ?>';
+                // Stored/used internally as a z value in [0,1000]; shown and entered as a
+                // percentage of full thrust (0-100%). % <-> z: z = pct * 10.
                 let hover_threshold = load_setting(hover_threshold_storage_key, CONST_DEFAULT_HOVER_THRESHOLD);
                 let hover_threshold_input = $('#<?php echo $id ?> #drone_control_commands_hover_threshold');
-                hover_threshold_input.val(hover_threshold);
+                hover_threshold_input.val(Math.round(hover_threshold / 10));
                 hover_threshold_input.on('change', function () {
-                    let entered = Math.max(0, Math.min(1000, Number($(this).val()) || CONST_DEFAULT_HOVER_THRESHOLD));
-                    hover_threshold = entered;
-                    $(this).val(entered);
-                    save_setting(hover_threshold_storage_key, entered);
+                    let raw = Number($(this).val());
+                    let pct = isNaN(raw) ? CONST_DEFAULT_HOVER_THRESHOLD / 10 : Math.max(0, Math.min(100, raw));
+                    pct = Math.round(pct);
+                    hover_threshold = pct * 10;
+                    $(this).val(pct);
+                    save_setting(hover_threshold_storage_key, hover_threshold);
                 });
 
                 // Max throttle: hard ceiling on the z command. Thrust can never be commanded
                 // above this, whatever the keyboard ramp or joystick asks for.
                 const max_throttle_storage_key = 'drone_control_max_throttle_<?php echo $id ?>';
+                // Same convention as the hover threshold: internal z in [0,1000], shown and
+                // entered as a percentage of full thrust (0-100%).
                 let max_throttle = load_setting(max_throttle_storage_key, CONST_DEFAULT_MAX_THROTTLE);
                 let max_throttle_input = $('#<?php echo $id ?> #drone_control_commands_max_throttle');
-                max_throttle_input.val(max_throttle);
+                max_throttle_input.val(Math.round(max_throttle / 10));
                 max_throttle_input.on('change', function () {
-                    let entered = Math.max(0, Math.min(1000, Number($(this).val()) || CONST_DEFAULT_MAX_THROTTLE));
-                    max_throttle = entered;
-                    $(this).val(entered);
-                    save_setting(max_throttle_storage_key, entered);
+                    let raw = Number($(this).val());
+                    let pct = isNaN(raw) ? CONST_DEFAULT_MAX_THROTTLE / 10 : Math.max(0, Math.min(100, raw));
+                    pct = Math.round(pct);
+                    max_throttle = pct * 10;
+                    $(this).val(pct);
+                    save_setting(max_throttle_storage_key, max_throttle);
                 });
 
                 // Native title tooltips always work; upgrade to Bootstrap tooltips when the

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -121,8 +121,7 @@ class Duckiedrone_Control extends BlockRenderer {
                     Intensity
                 </td>
                 <td rowspan="5" class="col-md-1 text-center" style="padding: 0; vertical-align: middle">
-                    <canvas id="drone_control_commands_throttle_gauge" width="56px" height="110px"></canvas>
-                    <div style="margin-top: 3px"
+                    <div style="margin-bottom: 3px"
                          data-toggle="tooltip" data-placement="top"
                          title="The throttle where the drone lifts off. Below it throttle rises fast, above it rises slowly for fine control. Blue line on the gauge.">
                         <label for="drone_control_commands_hover_threshold" style="display: block; font-size: 12px; margin: 0 0 1px; font-weight: normal">Hover %</label>
@@ -130,7 +129,7 @@ class Duckiedrone_Control extends BlockRenderer {
                                min="0" max="100" step="1"
                                style="width: 56px; font-size: 13px; padding: 1px 3px">
                     </div>
-                    <div style="margin-top: 5px"
+                    <div style="margin-bottom: 5px"
                          data-toggle="tooltip" data-placement="top"
                          title="The most throttle allowed. The drone never goes above this, whatever the keyboard or joystick asks for. Red line on the gauge.">
                         <label for="drone_control_commands_max_throttle" style="display: block; font-size: 12px; margin: 0 0 1px; font-weight: normal">Thrust Cap %</label>
@@ -138,6 +137,7 @@ class Duckiedrone_Control extends BlockRenderer {
                                min="0" max="100" step="1"
                                style="width: 56px; font-size: 13px; padding: 1px 3px">
                     </div>
+                    <canvas id="drone_control_commands_throttle_gauge" width="56px" height="110px"></canvas>
                 </td>
                 <td rowspan="5" class="col-md-2 text-center" style="padding: 0; vertical-align: middle">
                     <div style="font-weight: bold; color: #555">Roll / Pitch</div>

--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -140,12 +140,12 @@ class Duckiedrone_Control extends BlockRenderer {
                     </div>
                 </td>
                 <td rowspan="5" class="col-md-2 text-center" style="padding: 0; vertical-align: middle">
-                    <canvas id="drone_control_commands_joy_keys" width="150px" height="134px"></canvas>
-                    <div style="font-size: 13px; color: #555">Roll / Pitch</div>
+                    <div style="font-weight: bold; color: #555">Roll / Pitch</div>
+                    <canvas id="drone_control_commands_joy_keys" width="120px" height="120px"></canvas>
                 </td>
                 <td rowspan="5" class="col-md-2 text-center" style="padding: 0; vertical-align: middle">
+                    <div style="font-weight: bold; color: #555">Yaw / Throttle</div>
                     <div id="drone_control_commands_joy_stick" style="width:120px;height:120px;margin:0 auto;"></div>
-                    <div style="font-size: 13px; color: #555">Yaw / Throttle</div>
                 </td>
             </tr>
             <?php
@@ -732,9 +732,13 @@ class Duckiedrone_Control extends BlockRenderer {
                         left: [45, 50, 10, 50],
                         right: [55, 50, 90, 50],
                     };
-                    let scale = 1.2;
-                    let offsetX = 20;
-                    let offsetY = 20;
+                    // Canvas is 120x120. The arrows span base coords 10..90 (center 50);
+                    // scale 1.0 + offset 10 maps that to pixels 20..100, centered on 60,
+                    // leaving ~8px on every edge once the 20px stroke and arrowhead spread
+                    // are included, so no arrow clips.
+                    let scale = 1.0;
+                    let offsetX = 10;
+                    let offsetY = 10;
                     
                     for (let k in pos) {
                         pos[k] = pos[k].map(x => x * scale);

--- a/modules/renderers/blocks/Duckiedrone_IMU_Orientation.php
+++ b/modules/renderers/blocks/Duckiedrone_IMU_Orientation.php
@@ -30,12 +30,6 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
             "mandatory" => True,
             "default" => "~/px4_calibration/calibrate_gyro"
         ],
-        "accel_service" => [
-            "name" => "PX4 accel calibration service",
-            "type" => "text",
-            "mandatory" => True,
-            "default" => "~/px4_calibration/calibrate_accel"
-        ],
         "status_topic" => [
             "name" => "PX4 calibration status topic",
             "type" => "text",
@@ -57,10 +51,6 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
                 <i class="fa fa-crosshairs" aria-hidden="true"></i>
                 GYRO
             </button>
-            <button type="button" class="btn btn-warning btn-sm" id="px4_calibrate_accel">
-                <i class="fa fa-cube" aria-hidden="true"></i>
-                ACCEL
-            </button>
         </div>
         <div id="px4_calibration_status" class="duckiedrone-imu-status">PX4 calibration idle</div>
         <canvas class="resizable duckiedrone-imu-chart"></canvas>
@@ -76,7 +66,6 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
             $(document).on("<?php echo $connected_evt ?>", function (evt) {
                 let status_box = $("#<?php echo $id ?> #px4_calibration_status");
                 let gyro_btn = $("#<?php echo $id ?> #px4_calibrate_gyro");
-                let accel_btn = $("#<?php echo $id ?> #px4_calibrate_accel");
 
                 function normalize_ros_name(name) {
                     return name.replace(/^~\/+/, '/').replace(/^\/+/, '/');
@@ -95,11 +84,6 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
                     name: normalize_ros_name('<?php echo $args['gyro_service'] ?>'),
                     serviceType: 'std_srvs/srv/Trigger'
                 });
-                let accel_srv = new ROSLIB.Service({
-                    ros: window.ros['<?php echo $ros_hostname ?>'],
-                    name: normalize_ros_name('<?php echo $args['accel_service'] ?>'),
-                    serviceType: 'std_srvs/srv/Trigger'
-                });
                 let status_topic = new ROSLIB.Topic({
                     ros: window.ros['<?php echo $ros_hostname ?>'],
                     name: normalize_ros_name('<?php echo $args['status_topic'] ?>'),
@@ -109,7 +93,6 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
 
                 function set_busy(busy) {
                     gyro_btn.prop('disabled', busy);
-                    accel_btn.prop('disabled', busy);
                 }
 
                 function set_status(text, class_name) {
@@ -136,9 +119,6 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
 
                 gyro_btn.off().click(function () {
                     call_calibration(gyro_srv, 'gyro');
-                });
-                accel_btn.off().click(function () {
-                    call_calibration(accel_srv, 'accel');
                 });
                 status_topic.subscribe(function (message) {
                     set_status(message.data);

--- a/modules/renderers/blocks/Duckiedrone_IMU_Orientation.php
+++ b/modules/renderers/blocks/Duckiedrone_IMU_Orientation.php
@@ -30,6 +30,12 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
             "mandatory" => True,
             "default" => "~/px4_calibration/calibrate_gyro"
         ],
+        "level_service" => [
+            "name" => "PX4 level-horizon calibration service",
+            "type" => "text",
+            "mandatory" => True,
+            "default" => "~/px4_calibration/calibrate_level"
+        ],
         "status_topic" => [
             "name" => "PX4 calibration status topic",
             "type" => "text",
@@ -51,6 +57,10 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
                 <i class="fa fa-crosshairs" aria-hidden="true"></i>
                 GYRO
             </button>
+            <button type="button" class="btn btn-info btn-sm" id="px4_calibrate_level">
+                <i class="fa fa-balance-scale" aria-hidden="true"></i>
+                LEVEL
+            </button>
         </div>
         <div id="px4_calibration_status" class="duckiedrone-imu-status">PX4 calibration idle</div>
         <canvas class="resizable duckiedrone-imu-chart"></canvas>
@@ -66,6 +76,7 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
             $(document).on("<?php echo $connected_evt ?>", function (evt) {
                 let status_box = $("#<?php echo $id ?> #px4_calibration_status");
                 let gyro_btn = $("#<?php echo $id ?> #px4_calibrate_gyro");
+                let level_btn = $("#<?php echo $id ?> #px4_calibrate_level");
 
                 function normalize_ros_name(name) {
                     return name.replace(/^~\/+/, '/').replace(/^\/+/, '/');
@@ -84,6 +95,11 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
                     name: normalize_ros_name('<?php echo $args['gyro_service'] ?>'),
                     serviceType: 'std_srvs/srv/Trigger'
                 });
+                let level_srv = new ROSLIB.Service({
+                    ros: window.ros['<?php echo $ros_hostname ?>'],
+                    name: normalize_ros_name('<?php echo $args['level_service'] ?>'),
+                    serviceType: 'std_srvs/srv/Trigger'
+                });
                 let status_topic = new ROSLIB.Topic({
                     ros: window.ros['<?php echo $ros_hostname ?>'],
                     name: normalize_ros_name('<?php echo $args['status_topic'] ?>'),
@@ -93,6 +109,7 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
 
                 function set_busy(busy) {
                     gyro_btn.prop('disabled', busy);
+                    level_btn.prop('disabled', busy);
                 }
 
                 function set_status(text, class_name) {
@@ -119,6 +136,9 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
 
                 gyro_btn.off().click(function () {
                     call_calibration(gyro_srv, 'gyro');
+                });
+                level_btn.off().click(function () {
+                    call_calibration(level_srv, 'level');
                 });
                 status_topic.subscribe(function (message) {
                     set_status(message.data);

--- a/modules/renderers/blocks/Duckiedrone_IMU_Orientation.php
+++ b/modules/renderers/blocks/Duckiedrone_IMU_Orientation.php
@@ -216,9 +216,19 @@ class Duckiedrone_IMU_Orientation extends BlockRenderer {
                         message.orientation.z,
                     ];
                     let rpy = eulerFromQuaternion(q, "XYZ");
-                    config.data.datasets[0].data.push(rpy[0] * (180/Math.PI));
-                    config.data.datasets[1].data.push(rpy[1] * (180/Math.PI));
-                    config.data.datasets[2].data.push(rpy[2] * (180/Math.PI));
+                    // MAVROS reports orientation in ENU world / FLU body; the PX4 flight
+                    // controller reports attitude in NED world / FRD body. Convert so this
+                    // panel matches the FC convention (same mapping used for the PID LX):
+                    //   roll_NED  =  roll_ENU
+                    //   pitch_NED = -pitch_ENU
+                    //   yaw_NED   =  90deg - yaw_ENU   (then wrapped to [-180, 180])
+                    let roll = rpy[0] * (180/Math.PI);
+                    let pitch = -rpy[1] * (180/Math.PI);
+                    let yaw = 90 - rpy[2] * (180/Math.PI);
+                    yaw = ((yaw + 180) % 360 + 360) % 360 - 180;
+                    config.data.datasets[0].data.push(roll);
+                    config.data.datasets[1].data.push(pitch);
+                    config.data.datasets[2].data.push(yaw);
                     chart.update();
                 });
             });

--- a/modules/renderers/blocks/DuckietownMsgs_DroneMotorCommand.php
+++ b/modules/renderers/blocks/DuckietownMsgs_DroneMotorCommand.php
@@ -89,25 +89,25 @@ class DuckietownMsgs_DroneMotorCommand extends BlockRenderer {
                             backgroundColor: color(window.chartColors.red).alpha(0.5).rgbString(),
                             borderColor: window.chartColors.red,
                             fill: true,
-                            data: new Array(time_horizon_secs).fill(<?php echo $args["min_value"] ?>)
+                            data: new Array(time_horizon_secs).fill(0)
                         }, {
                             label: 'Motor 2',
                             backgroundColor: color(window.chartColors.blue).alpha(0.5).rgbString(),
                             borderColor: window.chartColors.blue,
                             fill: true,
-                            data: new Array(time_horizon_secs).fill(<?php echo $args["min_value"] ?>)
+                            data: new Array(time_horizon_secs).fill(0)
                         }, {
                             label: 'Motor 3',
                             backgroundColor: color(window.chartColors.green).alpha(0.5).rgbString(),
                             borderColor: window.chartColors.green,
                             fill: true,
-                            data: new Array(time_horizon_secs).fill(<?php echo $args["min_value"] ?>)
+                            data: new Array(time_horizon_secs).fill(0)
                         }, {
                             label: 'Motor 4',
                             backgroundColor: color(window.chartColors.purple).alpha(0.5).rgbString(),
                             borderColor: window.chartColors.purple,
                             fill: true,
-                            data: new Array(time_horizon_secs).fill(<?php echo $args["min_value"] ?>)
+                            data: new Array(time_horizon_secs).fill(0)
                         }]
                     },
                     options: {


### PR DESCRIPTION
Refactor the drone dashboard UI

Trims the dashboard down to what we actually fly today (STABILIZED manual flight, no autonomous takeoff), fixes the IMU panel to report attitude in the flight-controller's frame, and makes the throttle inputs human-readable.

Changes:

- Arming panel: removed the TAKEOFF button and the entire AUTO.TAKEOFF/AUTO.LAND JS flow. Flight is manual only now.
- Mode buttons: hid LOITER (AUTO.LOITER) and ALTITUDE (ALTCTL), kept in the DOM and JS wiring so they can be re-enabled later. STABILIZED and OFFBOARD stay visible.
- Calibration: replaced accel calibration with level-horizon calibration. Service calibrate_accel → calibrate_level, ACCEL button → LEVEL, updated in the IMU panel and the default mission config.
- IMU orientation panel: convert MAVROS ENU/FLU orientation to PX4 NED/FRD so the panel matches the FC convention (roll unchanged, pitch negated, yaw = 90° − yaw, wrapped). Same mapping the PID LX uses.
- Control panel: hover threshold and thrust cap are now entered and shown as percentages (0–100%) instead of raw z in [0,1000]; default thrust cap 400 (40%)—adjusted layout/styling of the throttle and thrust-cap controls.
- Yaw key: derive the yaw key magnitude from roll/pitch (CONST_YAW_KEY_VALUE = CONST_MAX_ROLL_PITCH / 10) so the yaw command rate matches the roll/pitch rate.
- Joystick: disabled mouse and touch input, keyboard-only control. The stick still renders and reflects state.
- Motor PWM chart: initialise the four motor datasets to 0 instead of min_value.

Note: the LEVEL and GYRO calibration buttons are wired up and fire the calibration service calls, but handling the response that comes back from those calls will be addressed in a separate PR.