### PR TITLE
DTSW-8174-Review-parent-PR

### DIFF
--- a/modules/renderers/blocks/Duckiedrone_Control.php
+++ b/modules/renderers/blocks/Duckiedrone_Control.php
@@ -471,7 +471,7 @@ class Duckiedrone_Control extends BlockRenderer {
 
                 let armed = false;
 
-                // Settings persist per widget instance across page reloads. localStorage can
+                // Settings persist per ROSbridge host across page reloads. localStorage can
                 // throw (private browsing, sandboxed iframe, storage disabled), so both calls
                 // are wrapped: a storage failure must never stop the setup below, or the
                 // manual_control publish loop would die and the drone could not arm.
@@ -496,7 +496,7 @@ class Duckiedrone_Control extends BlockRenderer {
                 // Users find it by ramping throttle up and reading the gauge/bar, then typing
                 // it in so the coarse->fine ramp switchover and the gauge line match their
                 // airframe.
-                const hover_threshold_storage_key = 'drone_control_hover_threshold_<?php echo $id ?>';
+                const hover_threshold_storage_key = 'drone_control_hover_threshold_<?php echo $ros_hostname ?>';
                 // Stored/used internally as a z value in [0,1000]; shown and entered as a
                 // percentage of full thrust (0-100%). % <-> z: z = pct * 10.
                 let hover_threshold = load_setting(hover_threshold_storage_key, CONST_DEFAULT_HOVER_THRESHOLD);
@@ -513,7 +513,7 @@ class Duckiedrone_Control extends BlockRenderer {
 
                 // Max throttle: hard ceiling on the z command. Thrust can never be commanded
                 // above this, whatever the keyboard ramp or joystick asks for.
-                const max_throttle_storage_key = 'drone_control_max_throttle_<?php echo $id ?>';
+                const max_throttle_storage_key = 'drone_control_max_throttle_<?php echo $ros_hostname ?>';
                 // Same convention as the hover threshold: internal z in [0,1000], shown and
                 // entered as a percentage of full thrust (0-100%).
                 let max_throttle = load_setting(max_throttle_storage_key, CONST_DEFAULT_MAX_THROTTLE);


### PR DESCRIPTION
This pull request updates the way settings are persisted for the Duckiedrone Control widget to improve user experience when working with multiple ROSbridge hosts. The main change is that settings are now stored per ROSbridge host instead of per widget instance, ensuring that users have consistent settings for each host regardless of how many widget instances they use.

**Settings persistence improvements:**

* Updated comments to clarify that settings now persist per ROSbridge host, not per widget instance.
* Changed the storage keys for `hover_threshold` and `max_throttle` to use `<?php echo $ros_hostname ?>` instead of `<?php echo $id ?>`, ensuring settings are saved and loaded based on the ROSbridge host. [[1]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51L499-R499) [[2]](diffhunk://#diff-9a40b6f4bcee1a28631cfa897b5caee460e5be8d0bae92a638f8cc2a45ba7a51L516-R516)